### PR TITLE
Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ code quality.
 
 - Reference inputs can be declared in transaction skeletons
 - Reference scripts can be declared in outputs of transaction skeletons
-- Datums in outputs of transaction skeletons can be declared as inlined, or
-  hashed (resolved or not in the transaction itself)
+- Datums in outputs of transaction skeletons can be declared as
+   - inlined, 
+   - hashed, with the resolved datum included on the transaction (i.e. as in Plutus V1), or
+   - hashed, without the resolved datum on the transaction.
 - New framework to search for UTxOs in the state using chainable filters
   that bring more type information
 - Parameterizable and revamped pretty-printing relying on `prettyprinter`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+## [Unreleased]
+
+This major update overhauls the entire library to: handle Plutus V2 features,
+improve transaction generation, the API, and the internal module structure and
+code quality.
+
+### New features
+
+- Reference inputs can be declared in transaction skeletons
+- Reference scripts can be declared in outputs of transaction skeletons
+- Datums in outputs of transaction skeletons can be declared as inlined, or
+  hashed (resolved or not in the transaction itself)
+- New framework to search for UTxOs in the state using chainable filters
+  that bring more type information
+- Parameterizable and revamped pretty-printing relying on `prettyprinter`
+
+### Changes
+
+- Transaction skeletons are now defined declaratively, no longer using lists of
+  constraints
+- Balancing and transaction generation no longer rely on `plutus-apps`, they
+  are performed entirely by cooked
+- Transaction skeletons need an explicit signer (no longer signed by a default
+  wallet)
+- Modules have been reorganized in a flatter tree and cleaned up
+
+## [[1.0.1]](https://github.com/tweag/plutus-libs/releases/tag/v1.0.1) - 2023-02-17
+
+### Fixes
+
+- Fixes wrong version number in the `.cabal` files
+
+## [[1.0.0]](https://github.com/tweag/plutus-libs/releases/tag/v1.0.0) - 2023-01-04
+
+Stable release covering Plutus V1. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ code quality.
 ### New features
 
 - Reference inputs can be declared in transaction skeletons.
-- Reference scripts can be declared in outputs of transaction skeletons.
+- Reference scripts can be declared in outputs of transaction skeletons and one
+  can spend inputs from a script that a transaction references.
 - Datums in outputs of transaction skeletons can be declared as
    - inlined, 
    - hashed, with the resolved datum included on the transaction (i.e. as in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,25 +8,26 @@ code quality.
 
 ### New features
 
-- Reference inputs can be declared in transaction skeletons
-- Reference scripts can be declared in outputs of transaction skeletons
+- Reference inputs can be declared in transaction skeletons.
+- Reference scripts can be declared in outputs of transaction skeletons.
 - Datums in outputs of transaction skeletons can be declared as
    - inlined, 
-   - hashed, with the resolved datum included on the transaction (i.e. as in Plutus V1), or
+   - hashed, with the resolved datum included on the transaction (i.e. as in
+     Plutus V1), or
    - hashed, without the resolved datum on the transaction.
-- New framework to search for UTxOs in the state using chainable filters
-  that bring more type information
+- New framework to search for UTxOs in the state using chainable filters that
+  bring more type information.
 - Parameterizable and revamped pretty-printing relying on `prettyprinter`
 
 ### Changes
 
 - Transaction skeletons are now defined declaratively, no longer using lists of
-  constraints
+  constraints.
 - Balancing and transaction generation no longer rely on `plutus-apps`, they
-  are performed entirely by cooked
+  are performed entirely by cooked.
 - Transaction skeletons need an explicit signer (no longer signed by a default
-  wallet)
-- Modules have been reorganized in a flatter tree and cleaned up
+  wallet).
+- Modules have been reorganized in a flatter tree and cleaned up.
 
 ## [[1.0.1]](https://github.com/tweag/plutus-libs/releases/tag/v1.0.1) - 2023-02-17
 


### PR DESCRIPTION
This adds a changelog file that roughly follows https://keepachangelog.com guidelines. As agreed with @gabrielhdt, considering the amount of changes from v1, the changelog for V2 is kept extremely concise and high level. It would quickly turn into a documentation if we were to detail every single item, and as mentioned on https://keepachangelog.com, changelogs that are paraphrasing git logs are not very useful.

Feel free to add and modify elements (in particular deprecations or other API changes that would be important to mention).

We should also mention which versioning template we use (for now it is semantic versioning but we were discussing about switching to Haskell PVP).