### PR TITLE
Better generated documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,17 +227,17 @@ jobs:
           name: tweag-plutus-libs
           ## No auth token: read only cache.
 
-      # ## Example from
-      # ## https://github.com/actions/cache/blob/ac25611caef967612169ab7e95533cf932c32270/examples.md#haskell---cabal
-      # - name: Accessing the Cabal cache
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: |
-      #       ~/.cabal/packages
-      #       ~/.cabal/store
-      #       dist-newstyle
-      #     key: ${{ runner.os }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze', 'flake.nix', 'flake.lock') }}-haddock
-      #     restore-keys: ${{ runner.os }}-
+      ## Example from
+      ## https://github.com/actions/cache/blob/ac25611caef967612169ab7e95533cf932c32270/examples.md#haskell---cabal
+      - name: Accessing the Cabal cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze', 'flake.nix', 'flake.lock') }}-haddock
+          restore-keys: ${{ runner.os }}-
 
       - name: Build documentation
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,10 +246,7 @@ jobs:
 
             cabal update
 
-            cabal haddock \
-              --haddock-hyperlink-source \
-              --haddock-html-location="http://hackage.haskell.org/packages/archive/\$pkg/latest/doc/html" \
-              cooked-validators
+            cabal haddock --haddock-for-hackage cooked-validators
 
             mkdir -p docs
             cp --force --recursive dist-newstyle/build/*/ghc-*/cooked-validators-*/doc/html/cooked-validators/* docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,8 @@ jobs:
             cabal update
 
             cabal haddock \
-                --haddock-for-hackage \
+                --haddock-html-location='https://hackage.haskell.org/package/$pkg-$version/docs' \
+                --haddock-hyperlink-source \
                 --haddock-quickjump \
                 cooked-validators
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,10 +247,10 @@ jobs:
             cabal update
 
             cabal haddock \
-                --haddock-html-location='https://hackage.haskell.org/package/$pkg-$version/docs' \
-                --haddock-hyperlink-source \
-                --haddock-quickjump \
-                cooked-validators
+              --haddock-hyperlink-source \
+              --haddock-quickjump \
+              --haddock-html-location='https://hackage.haskell.org/package/$pkg-$version/docs' \
+              cooked-validators
 
             mkdir -p docs
             cp --force --recursive dist-newstyle/build/*/ghc-*/cooked-validators-*/doc/html/cooked-validators/* docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,17 +227,17 @@ jobs:
           name: tweag-plutus-libs
           ## No auth token: read only cache.
 
-      # ## Example from
-      # ## https://github.com/actions/cache/blob/ac25611caef967612169ab7e95533cf932c32270/examples.md#haskell---cabal
-      # - name: Accessing the Cabal cache
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: |
-      #       ~/.cabal/packages
-      #       ~/.cabal/store
-      #       dist-newstyle
-      #     key: ${{ runner.os }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}-haddock
-      #     restore-keys: ${{ runner.os }}-
+      ## Example from
+      ## https://github.com/actions/cache/blob/ac25611caef967612169ab7e95533cf932c32270/examples.md#haskell---cabal
+      - name: Accessing the Cabal cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}-haddock
+          restore-keys: ${{ runner.os }}-
 
       - name: Build documentation
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,17 +227,17 @@ jobs:
           name: tweag-plutus-libs
           ## No auth token: read only cache.
 
-      ## Example from
-      ## https://github.com/actions/cache/blob/ac25611caef967612169ab7e95533cf932c32270/examples.md#haskell---cabal
-      - name: Accessing the Cabal cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cabal/packages
-            ~/.cabal/store
-            dist-newstyle
-          key: ${{ runner.os }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze', 'flake.nix', 'flake.lock') }}-haddock
-          restore-keys: ${{ runner.os }}-
+      # ## Example from
+      # ## https://github.com/actions/cache/blob/ac25611caef967612169ab7e95533cf932c32270/examples.md#haskell---cabal
+      # - name: Accessing the Cabal cache
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: |
+      #       ~/.cabal/packages
+      #       ~/.cabal/store
+      #       dist-newstyle
+      #     key: ${{ runner.os }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze', 'flake.nix', 'flake.lock') }}-haddock
+      #     restore-keys: ${{ runner.os }}-
 
       - name: Build documentation
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,17 +227,17 @@ jobs:
           name: tweag-plutus-libs
           ## No auth token: read only cache.
 
-      ## Example from
-      ## https://github.com/actions/cache/blob/ac25611caef967612169ab7e95533cf932c32270/examples.md#haskell---cabal
-      - name: Accessing the Cabal cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cabal/packages
-            ~/.cabal/store
-            dist-newstyle
-          key: ${{ runner.os }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}-haddock
-          restore-keys: ${{ runner.os }}-
+      # ## Example from
+      # ## https://github.com/actions/cache/blob/ac25611caef967612169ab7e95533cf932c32270/examples.md#haskell---cabal
+      # - name: Accessing the Cabal cache
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: |
+      #       ~/.cabal/packages
+      #       ~/.cabal/store
+      #       dist-newstyle
+      #     key: ${{ runner.os }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}-haddock
+      #     restore-keys: ${{ runner.os }}-
 
       - name: Build documentation
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,12 @@ jobs:
             cp --force --recursive dist-newstyle/build/*/ghc-*/cooked-validators-*/doc/html/cooked-validators/* docs
           '
 
+      - name: Upload documentation as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: documentation
+          path: ./docs
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,10 @@ jobs:
 
             cabal update
 
-            cabal haddock --haddock-for-hackage cooked-validators
+            cabal haddock \
+                --haddock-for-hackage \
+                --haddock-quickjump \
+                cooked-validators
 
             mkdir -p docs
             cp --force --recursive dist-newstyle/build/*/ghc-*/cooked-validators-*/doc/html/cooked-validators/* docs

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,6 @@
             glibcLocales
           ]);
 
-          ## Needed by `pirouette-plutusir` and `cooked`
           LD_LIBRARY_PATH = with pkgs;
             lib.strings.makeLibraryPath [ libsodium zlib xz ];
           LANG = "C.UTF-8";

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
             glibcLocales
           ]);
 
+          ## Needed by `pirouette-plutusir` and `cooked`
           LD_LIBRARY_PATH = with pkgs;
             lib.strings.makeLibraryPath [ libsodium zlib xz ];
           LANG = "C.UTF-8";


### PR DESCRIPTION
This PR:

- cleans up ever so slightly the `haddock` invocation
- asks Haddock to generate the “Quick Jump” index
- uploads the documentation as artefact so we can download it (eg. to check it manually)