### PR TITLE
More instances of `PrettyCooked`

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/Testing.hs
+++ b/cooked-validators/src/Cooked/MockChain/Testing.hs
@@ -153,7 +153,7 @@ testAllSatisfiesFrom ::
 testAllSatisfiesFrom pcOpts f = testSatisfiesFrom' (testAll go)
   where
     go :: (Either MockChainError (a, UtxoState), MockChainLog) -> prop
-    go (prop, mcLog) = testCounterexample (renderString (prettyMockChainLog pcOpts) mcLog) (f prop)
+    go (prop, mcLog) = testCounterexample (renderString (prettyCookedOpt pcOpts) mcLog) (f prop)
 
 -- | Asserts that the given 'StagedMockChain' produces exactly two outcomes, both of which
 -- are successful and have their resulting states related by a given predicate. A typical
@@ -173,9 +173,9 @@ testBinaryRelatedBy pcOpts rel = testSatisfiesFrom' $ \case
   [(ra, ta), (rb, tb)] -> case (ra, rb) of
     (Right resA, Right resB) -> rel (snd resA) (snd resB)
     (Left errA, Right _) ->
-      testFailureMsg $ concat ["Expected two outcomes, the first failed with:", renderString (prettyCookedOpt pcOpts) errA, "\n", renderString (prettyMockChainLog pcOpts) ta]
+      testFailureMsg $ concat ["Expected two outcomes, the first failed with:", renderString (prettyCookedOpt pcOpts) errA, "\n", renderString (prettyCookedOpt pcOpts) ta]
     (Right _, Left errB) ->
-      testFailureMsg $ concat ["Expected two outcomes, the second failed with:", renderString (prettyCookedOpt pcOpts) errB, "\n", renderString (prettyMockChainLog pcOpts) tb]
+      testFailureMsg $ concat ["Expected two outcomes, the second failed with:", renderString (prettyCookedOpt pcOpts) errB, "\n", renderString (prettyCookedOpt pcOpts) tb]
     (Left errA, Left errB) ->
       testFailureMsg $
         concat
@@ -184,9 +184,9 @@ testBinaryRelatedBy pcOpts rel = testSatisfiesFrom' $ \case
             "; ",
             renderString (prettyCookedOpt pcOpts) errB,
             "\n First: ",
-            renderString (prettyMockChainLog pcOpts) ta,
+            renderString (prettyCookedOpt pcOpts) ta,
             "\nSecond: ",
-            renderString (prettyMockChainLog pcOpts) tb
+            renderString (prettyCookedOpt pcOpts) tb
           ]
   xs -> testFailureMsg $ "Expected exactly two outcomes, received: " ++ show (length xs)
 
@@ -208,13 +208,13 @@ testOneEquivClass ::
 testOneEquivClass pcOpts rel = testSatisfiesFrom' $ \case
   [] -> testFailureMsg "Expected two of more outcomes, received: 0"
   [_] -> testFailureMsg "Expected two of more outcomes, received: 1"
-  ((Left errX, tx) : _) -> testFailureMsg $ concat ["First outcome is a failure: ", renderString (prettyCookedOpt pcOpts) errX, "\n", renderString (prettyMockChainLog pcOpts) tx]
+  ((Left errX, tx) : _) -> testFailureMsg $ concat ["First outcome is a failure: ", renderString (prettyCookedOpt pcOpts) errX, "\n", renderString (prettyCookedOpt pcOpts) tx]
   ((Right resX, _) : xs) -> go (snd resX) xs
   where
     -- we can flag a success here because 'xs' above is guarnateed to have at least
     -- one element since we ruled out the empty and the singleton lists in the \case
     go _resX [] = testSuccess
-    go _resX ((Left errY, ty) : _) = testFailureMsg $ concat ["An outcome is a failure: ", renderString (prettyCookedOpt pcOpts) errY, "\n", renderString (prettyMockChainLog pcOpts) ty]
+    go _resX ((Left errY, ty) : _) = testFailureMsg $ concat ["An outcome is a failure: ", renderString (prettyCookedOpt pcOpts) errY, "\n", renderString (prettyCookedOpt pcOpts) ty]
     go resX ((Right (_, resY), _) : ys) = testConjoin [rel resX resY, go resX ys]
 
 -- | Asserts that the results produced by running the given 'StagedMockChain' from

--- a/cooked-validators/src/Cooked/Pretty/Class.hs
+++ b/cooked-validators/src/Cooked/Pretty/Class.hs
@@ -46,7 +46,7 @@ instance PrettyCooked Pl.TxId where
 
 instance PrettyCooked Pl.TxOutRef where
   prettyCookedOpt opts (Pl.TxOutRef txId index) =
-    prettyHash (pcOptPrintedHashLength opts) txId <> "!" <> PP.pretty index
+    prettyHash (pcOptPrintedHashLength opts) txId <> "!" <> prettyCookedOpt opts index
 
 instance PrettyCooked (Pl.Versioned Pl.MintingPolicy) where
   prettyCookedOpt opts = prettyHash (pcOptPrintedHashLength opts) . Pl.mintingPolicyHash
@@ -99,7 +99,7 @@ instance PrettyCooked Pl.Value where
       prettySingletons docs = prettyItemize "Value:" "-" docs
       prettySingletonValue :: (Pl.CurrencySymbol, Pl.TokenName, Integer) -> DocCooked
       prettySingletonValue (symbol, name, amount) =
-        prettyAssetClass <> ":" <+> prettyNumericUnderscore amount
+        prettyAssetClass <> ":" <+> prettyCookedOpt opts amount
         where
           prettyAssetClass
             | symbol == Pl.CurrencySymbol "" = "Lovelace"
@@ -119,7 +119,10 @@ instance PrettyCooked Int where
   prettyCookedOpt _ = PP.pretty
 
 instance PrettyCooked Integer where
-  prettyCookedOpt _ = PP.pretty
+  prettyCookedOpt opts =
+    if pcOptNumericUnderscores opts
+      then prettyNumericUnderscore
+      else PP.pretty
 
 instance PrettyCooked Bool where
   prettyCookedOpt _ = PP.pretty

--- a/cooked-validators/src/Cooked/Pretty/Class.hs
+++ b/cooked-validators/src/Cooked/Pretty/Class.hs
@@ -112,6 +112,9 @@ instance PrettyCooked Pl.ValidationErrorInPhase where
   -- 'ValueNotPreserved'
   prettyCookedOpt _ = PP.pretty
 
+instance PrettyCooked Pl.POSIXTime where
+  prettyCookedOpt opts (Pl.POSIXTime n) = "POSIXTime" <+> prettyCookedOpt opts n
+
 instance PrettyCooked a => PrettyCooked [a] where
   prettyCookedOpt opts = prettyItemizeNoTitle "-" . map (prettyCookedOpt opts)
 

--- a/cooked-validators/src/Cooked/Pretty/Class.hs
+++ b/cooked-validators/src/Cooked/Pretty/Class.hs
@@ -111,3 +111,18 @@ instance PrettyCooked Pl.ValidationErrorInPhase where
   -- TODO Implement better pretty-printing for errors such as
   -- 'ValueNotPreserved'
   prettyCookedOpt _ = PP.pretty
+
+instance PrettyCooked a => PrettyCooked [a] where
+  prettyCookedOpt opts = prettyItemizeNoTitle "-" . map (prettyCookedOpt opts)
+
+instance PrettyCooked Int where
+  prettyCookedOpt _ = PP.pretty
+
+instance PrettyCooked Integer where
+  prettyCookedOpt _ = PP.pretty
+
+instance PrettyCooked Bool where
+  prettyCookedOpt _ = PP.pretty
+
+instance PrettyCooked () where
+  prettyCookedOpt _ = PP.pretty

--- a/cooked-validators/src/Cooked/Pretty/Class.hs
+++ b/cooked-validators/src/Cooked/Pretty/Class.hs
@@ -126,6 +126,19 @@ instance PrettyCooked Integer where
     if pcOptNumericUnderscores opts
       then prettyNumericUnderscore
       else PP.pretty
+    where
+      -- prettyNumericUnderscore 23798423723
+      -- 23_798_423_723
+      prettyNumericUnderscore :: Integer -> DocCooked
+      prettyNumericUnderscore i
+        | 0 == i = "0"
+        | i > 0 = psnTerm "" 0 i
+        | otherwise = "-" <> psnTerm "" 0 (-i)
+        where
+          psnTerm :: DocCooked -> Integer -> Integer -> DocCooked
+          psnTerm acc _ 0 = acc
+          psnTerm acc 3 nb = psnTerm (PP.pretty (nb `mod` 10) <> "_" <> acc) 1 (nb `div` 10)
+          psnTerm acc n nb = psnTerm (PP.pretty (nb `mod` 10) <> acc) (n + 1) (nb `div` 10)
 
 instance PrettyCooked Bool where
   prettyCookedOpt _ = PP.pretty

--- a/cooked-validators/src/Cooked/Pretty/Common.hs
+++ b/cooked-validators/src/Cooked/Pretty/Common.hs
@@ -24,9 +24,11 @@ prettyItemize :: DocCooked -> DocCooked -> [DocCooked] -> DocCooked
 prettyItemize title bullet items =
   PP.vsep
     [ title,
-      PP.indent 2 . PP.vsep $
-        map (bullet <+>) items
+      PP.indent 2 . prettyItemizeNoTitle bullet $ items
     ]
+
+prettyItemizeNoTitle :: DocCooked -> [DocCooked] -> DocCooked
+prettyItemizeNoTitle bullet = PP.vsep . map (bullet <+>)
 
 prettyItemizeNonEmpty :: DocCooked -> DocCooked -> [DocCooked] -> Maybe DocCooked
 prettyItemizeNonEmpty _ _ [] = Nothing

--- a/cooked-validators/src/Cooked/Pretty/Common.hs
+++ b/cooked-validators/src/Cooked/Pretty/Common.hs
@@ -46,16 +46,3 @@ prettyEnumerate title bullet items =
 -- #28a3d9
 prettyHash :: (Show a) => Int -> a -> DocCooked
 prettyHash printedLength = PP.pretty . ('#' :) . take printedLength . show
-
--- prettyNumericUnderscore 23798423723
--- 23_798_423_723
-prettyNumericUnderscore :: Integer -> DocCooked
-prettyNumericUnderscore i
-  | 0 == i = "0"
-  | i > 0 = psnTerm "" 0 i
-  | otherwise = "-" <> psnTerm "" 0 (-i)
-  where
-    psnTerm :: DocCooked -> Integer -> Integer -> DocCooked
-    psnTerm acc _ 0 = acc
-    psnTerm acc 3 nb = psnTerm (PP.pretty (nb `mod` 10) <> "_" <> acc) 1 (nb `div` 10)
-    psnTerm acc n nb = psnTerm (PP.pretty (nb `mod` 10) <> acc) (n + 1) (nb `div` 10)

--- a/cooked-validators/src/Cooked/Pretty/Cooked.hs
+++ b/cooked-validators/src/Cooked/Pretty/Cooked.hs
@@ -445,7 +445,7 @@ prettyPayloadGrouped opts [payload] =
     payload
 prettyPayloadGrouped opts (payload : rest) =
   let cardinality = 1 + length rest
-   in (PP.parens ("×" <> PP.pretty cardinality) <+>)
+   in (PP.parens ("×" <> prettyCookedOpt opts cardinality) <+>)
         <$> prettyPayload opts False payload
 
 prettyPayload :: PrettyCookedOpts -> Bool -> UtxoPayload -> Maybe DocCooked

--- a/cooked-validators/src/Cooked/Pretty/Cooked.hs
+++ b/cooked-validators/src/Cooked/Pretty/Cooked.hs
@@ -137,7 +137,7 @@ instance Show a => PrettyCooked (a, UtxoState) where
     prettyItemize
       "End state:"
       "-"
-      ["Returns:" <+> PP.viaShow res, prettyUtxoState opts state]
+      ["Returns:" <+> PP.viaShow res, prettyCookedOpt opts state]
 
 instance Show a => PrettyCooked (Either MockChainError (a, UtxoState)) where
   prettyCookedOpt opts (Left err) = "🔴" <+> prettyCookedOpt opts err
@@ -385,27 +385,27 @@ mPrettyTxOpts
 
 -- | Pretty prints a 'UtxoState'. Print the known wallets first, then unknown
 -- pks, then scripts.
-prettyUtxoState :: PrettyCookedOpts -> UtxoState -> DocCooked
-prettyUtxoState opts =
-  prettyItemize "UTxO state:" "•"
-    . map (uncurry (prettyAddressState opts))
-    . List.sortBy addressOrdering
-    . Map.toList
-    . utxoState
-  where
-    addressOrdering :: (Pl.Address, a) -> (Pl.Address, a) -> Ordering
-    addressOrdering
-      (a1@(Pl.Address (Pl.PubKeyCredential pkh1) _), _)
-      (a2@(Pl.Address (Pl.PubKeyCredential pkh2) _), _) =
-        case (walletPKHashToId pkh1, walletPKHashToId pkh2) of
-          (Just i, Just j) -> compare i j
-          (Just _, Nothing) -> LT
-          (Nothing, Just _) -> GT
-          (Nothing, Nothing) -> compare a1 a2
-    addressOrdering
-      (Pl.Address (Pl.PubKeyCredential _) _, _)
-      (Pl.Address (Pl.ScriptCredential _) _, _) = LT
-    addressOrdering (a1, _) (a2, _) = compare a1 a2
+instance PrettyCooked UtxoState where
+  prettyCookedOpt opts =
+    prettyItemize "UTxO state:" "•"
+      . map (uncurry (prettyAddressState opts))
+      . List.sortBy addressOrdering
+      . Map.toList
+      . utxoState
+    where
+      addressOrdering :: (Pl.Address, a) -> (Pl.Address, a) -> Ordering
+      addressOrdering
+        (a1@(Pl.Address (Pl.PubKeyCredential pkh1) _), _)
+        (a2@(Pl.Address (Pl.PubKeyCredential pkh2) _), _) =
+          case (walletPKHashToId pkh1, walletPKHashToId pkh2) of
+            (Just i, Just j) -> compare i j
+            (Just _, Nothing) -> LT
+            (Nothing, Just _) -> GT
+            (Nothing, Nothing) -> compare a1 a2
+      addressOrdering
+        (Pl.Address (Pl.PubKeyCredential _) _, _)
+        (Pl.Address (Pl.ScriptCredential _) _, _) = LT
+      addressOrdering (a1, _) (a2, _) = compare a1 a2
 
 -- | Pretty prints the state of an address, that is the list of utxos
 -- (including value and datum), grouped

--- a/cooked-validators/src/Cooked/Pretty/Cooked.hs
+++ b/cooked-validators/src/Cooked/Pretty/Cooked.hs
@@ -146,43 +146,44 @@ instance Show a => PrettyCooked (Either MockChainError (a, UtxoState)) where
 -- | This pretty prints a mock chain log that usually consists of the list of
 -- validated or submitted transactions. In the log, we know a transaction has
 -- been validated if the 'MCLogSubmittedTxSkel' is followed by a 'MCLogNewTx'.
-prettyMockChainLog :: PrettyCookedOpts -> MockChainLog -> DocCooked
-prettyMockChainLog opts =
-  prettyEnumerate "MockChain run:" "."
-    . go []
-  where
-    -- In order to avoid printing 'MockChainLogValidateTxSkel' then
-    -- 'MockChainLogNewTx' as two different items, we combine them into one
-    -- single 'DocCooked'
-    go :: [DocCooked] -> [MockChainLogEntry] -> [DocCooked]
-    go
-      acc
-      ( MCLogSubmittedTxSkel skelContext skel
-          : MCLogNewTx txId
-          : entries
-        )
-        | pcOptPrintTxHashes opts =
-          go
-            ( "Validated"
-                <+> PP.parens ("TxId:" <+> prettyCookedOpt opts txId)
-                <+> prettyTxSkel opts skelContext skel :
-              acc
-            )
-            entries
-        | otherwise = go ("Validated" <+> prettyTxSkel opts skelContext skel : acc) entries
-    go
-      acc
-      ( MCLogSubmittedTxSkel skelContext skel
-          : entries
-        ) =
-        go ("Submitted" <+> prettyTxSkel opts skelContext skel : acc) entries
-    go acc (MCLogFail msg : entries) =
-      go ("Fail:" <+> PP.pretty msg : acc) entries
-    -- This case is not supposed to occur because it should follow a
-    -- 'MCLogSubmittedTxSkel'
-    go acc (MCLogNewTx txId : entries) =
-      go ("New transaction:" <+> prettyCookedOpt opts txId : acc) entries
-    go acc [] = reverse acc
+instance PrettyCooked MockChainLog where
+  prettyCookedOpt opts =
+    prettyEnumerate "MockChain run:" "."
+      . go []
+      . unMockChainLog
+    where
+      -- In order to avoid printing 'MockChainLogValidateTxSkel' then
+      -- 'MockChainLogNewTx' as two different items, we combine them into one
+      -- single 'DocCooked'
+      go :: [DocCooked] -> [MockChainLogEntry] -> [DocCooked]
+      go
+        acc
+        ( MCLogSubmittedTxSkel skelContext skel
+            : MCLogNewTx txId
+            : entries
+          )
+          | pcOptPrintTxHashes opts =
+            go
+              ( "Validated"
+                  <+> PP.parens ("TxId:" <+> prettyCookedOpt opts txId)
+                  <+> prettyTxSkel opts skelContext skel :
+                acc
+              )
+              entries
+          | otherwise = go ("Validated" <+> prettyTxSkel opts skelContext skel : acc) entries
+      go
+        acc
+        ( MCLogSubmittedTxSkel skelContext skel
+            : entries
+          ) =
+          go ("Submitted" <+> prettyTxSkel opts skelContext skel : acc) entries
+      go acc (MCLogFail msg : entries) =
+        go ("Fail:" <+> PP.pretty msg : acc) entries
+      -- This case is not supposed to occur because it should follow a
+      -- 'MCLogSubmittedTxSkel'
+      go acc (MCLogNewTx txId : entries) =
+        go ("New transaction:" <+> prettyCookedOpt opts txId : acc) entries
+      go acc [] = reverse acc
 
 prettyTxSkel :: PrettyCookedOpts -> SkelContext -> TxSkel -> DocCooked
 prettyTxSkel opts skelContext (TxSkel lbl txopts mints validityRange signers ins insReference outs) =

--- a/cooked-validators/src/Cooked/Pretty/Options.hs
+++ b/cooked-validators/src/Cooked/Pretty/Options.hs
@@ -16,7 +16,11 @@ data PrettyCookedOpts = PrettyCookedOpts
     pcOptPrintDefaultTxOpts :: Bool,
     -- | Length of printed hashes (e.g. addresses, tx ids)
     -- By default: 7
-    pcOptPrintedHashLength :: Int
+    pcOptPrintedHashLength :: Int,
+    -- | Whether to print big integers with numeric underscores.
+    -- For example @53_000_000@ instead of @53000000@.
+    -- By default: True
+    pcOptNumericUnderscores :: Bool
   }
   deriving (Eq, Show)
 
@@ -40,5 +44,6 @@ instance Default PrettyCookedOpts where
       { pcOptPrintTxHashes = False,
         pcOptPrintTxOutRefs = PCOptTxOutRefsHidden,
         pcOptPrintDefaultTxOpts = False,
-        pcOptPrintedHashLength = 7
+        pcOptPrintedHashLength = 7,
+        pcOptNumericUnderscores = True
       }

--- a/cooked-validators/tests/Cooked/Attack/DatumHijackingSpec.hs
+++ b/cooked-validators/tests/Cooked/Attack/DatumHijackingSpec.hs
@@ -41,9 +41,6 @@ data MockDatum = FirstLock | SecondLock deriving (Show, Eq)
 instance PrettyCooked MockDatum where
   prettyCooked = viaShow
 
-instance PrettyCooked () where
-  prettyCooked = viaShow
-
 instance Pl.Eq MockDatum where
   {-# INLINEABLE (==) #-}
   FirstLock == FirstLock = True

--- a/cooked-validators/tests/Cooked/InlineDatumsSpec.hs
+++ b/cooked-validators/tests/Cooked/InlineDatumsSpec.hs
@@ -42,9 +42,6 @@ data SimpleContractDatum = FirstPaymentDatum | SecondPaymentDatum deriving (Show
 instance PrettyCooked SimpleContractDatum where
   prettyCooked = viaShow
 
-instance PrettyCooked () where
-  prettyCooked = viaShow
-
 instance Pl.Eq SimpleContractDatum where
   FirstPaymentDatum == FirstPaymentDatum = True
   SecondPaymentDatum == SecondPaymentDatum = True

--- a/cooked-validators/tests/Cooked/MinAdaSpec.hs
+++ b/cooked-validators/tests/Cooked/MinAdaSpec.hs
@@ -16,9 +16,6 @@ import qualified Prettyprinter as PP
 import Test.Tasty
 import Test.Tasty.HUnit
 
-instance PrettyCooked [Integer] where
-  prettyCooked = PP.pretty
-
 heavyDatum :: [Integer]
 heavyDatum = take 100 [0 ..]
 

--- a/cooked-validators/tests/Cooked/ReferenceInputsSpec.hs
+++ b/cooked-validators/tests/Cooked/ReferenceInputsSpec.hs
@@ -44,9 +44,6 @@ newtype FooDatum = FooDatum Pl.PubKeyHash deriving (Show)
 instance PrettyCooked FooDatum where
   prettyCookedOpt opts (FooDatum pkh) = "FooDatum" PP.<+> prettyCookedOpt opts pkh
 
-instance PrettyCooked () where
-  prettyCooked = PP.pretty
-
 instance Pl.Eq FooDatum where
   FooDatum pkh1 == FooDatum pkh2 = pkh1 == pkh2
 

--- a/cooked-validators/tests/Cooked/ReferenceScriptsSpec.hs
+++ b/cooked-validators/tests/Cooked/ReferenceScriptsSpec.hs
@@ -32,9 +32,6 @@ instance Pl.ValidatorTypes MockContract where
   type RedeemerType MockContract = ()
   type DatumType MockContract = ()
 
-instance PrettyCooked () where
-  prettyCooked = PP.pretty
-
 -- | The validator that always agrees to the transaction
 yesValidator :: Pl.TypedValidator MockContract
 yesValidator =

--- a/examples/src/Auction.hs
+++ b/examples/src/Auction.hs
@@ -213,14 +213,14 @@ instance Cooked.PrettyCooked AuctionState where
       "-"
       [ "seller:" <+> Cooked.prettyCookedOpt opts seller,
         "minimum bid:" <+> Cooked.prettyCookedOpt opts (Ada.lovelaceValueOf minBid),
-        "deadline" <+> PP.pretty deadline
+        "deadline" <+> Cooked.prettyCookedOpt opts deadline
       ]
   prettyCookedOpt opts (Bidding seller deadline (BidderInfo lastBid lastBidder)) =
     Cooked.prettyItemize
       "Bidding"
       "-"
       [ "seller:" <+> Cooked.prettyCookedOpt opts seller,
-        "deadline" <+> PP.pretty deadline,
+        "deadline" <+> Cooked.prettyCookedOpt opts deadline,
         "previous bidder:" <+> Cooked.prettyCookedOpt opts lastBidder,
         "previous bid:" <+> Cooked.prettyCookedOpt opts (Ada.lovelaceValueOf lastBid)
       ]


### PR DESCRIPTION
This adds instances of `PrettyCooked` for:
* some common types in `Cooked.Pretty.Class` including lists, integers, booleans, and unit (it also removes manual instances made in tests)
* some cooked types when relevant in `Cooked.Pretty.Cooked`. Note that `MockChainLog` is now a list wrapped in a newtype to avoid conflicting instances with the newly introduced list instance
* `POSIXTimeRange` to benefit from numeric underscores (those values are usually very big)

It also adds a pretty printing option `pcOptNumericUnderscores` to turn on (default) or off the markers every 3 digits in big `Integers`