### PR TITLE
Provide required libraries in development shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
             zlib
             xz
             glibcLocales
+            postgresql # For pg_config
           ]);
 
           ## Needed by `pirouette-plutusir` and `cooked`

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
               libsodium
               zlib
               xz
-              postgresql
+              postgresql # For cardano-node-emulator
               openldap # For freer-extras‽
             ];
           LANG = "C.UTF-8";

--- a/flake.nix
+++ b/flake.nix
@@ -29,13 +29,12 @@
             pkg-config
             zlib
             xz
-            postgresql # For pg_config
             glibcLocales
           ]);
 
           ## Needed by `pirouette-plutusir` and `cooked`
           LD_LIBRARY_PATH = with pkgs;
-            lib.strings.makeLibraryPath [ libsodium zlib xz ];
+            lib.strings.makeLibraryPath [ libsodium zlib xz postgresql ];
           LANG = "C.UTF-8";
         in {
           ci = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,13 @@
 
           ## Needed by `pirouette-plutusir` and `cooked`
           LD_LIBRARY_PATH = with pkgs;
-            lib.strings.makeLibraryPath [ libsodium zlib xz postgresql ];
+            lib.strings.makeLibraryPath [
+              libsodium
+              zlib
+              xz
+              postgresql
+              openldap # For freer-extras‽
+            ];
           LANG = "C.UTF-8";
         in {
           ci = pkgs.mkShell {


### PR DESCRIPTION
libpq.so.5 is needed, but perhaps we can do without postgresql binaries. This may fix the build workflow. In particular, this PR ought to trigger a rebuild of all cabal files because the cache key depends on the flake.