### PR TITLE
Fail if building documentation failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,8 @@ jobs:
       - name: Build and run tests
         run: |
           nix develop .#ci --command bash -c '
-            ## NOTE: `-x` and `-u` are here to help us avoid making mistakes.
+            ## NOTE: `-u` is here to help us avoid making mistakes.
+            ##       `-x` is here to help with debugging.
             ##
             ## NOTE: `-o pipefail` is important for the semantics of this
             ## script, because with pipe the result of `cabal build` and `cabal
@@ -248,7 +249,9 @@ jobs:
       - name: Build documentation
         run: |
           nix develop .#ci --command bash -c '
-            set -o xtrace
+            ## NOTE: `-e` and `-u` are here to help us avoid making mistakes.
+            ##       `-x` is here to help with debugging.
+            set -eux
 
             cabal update
 


### PR DESCRIPTION
Before this change, failure to build the documentation would not lead to failure of the CI job. It would not lead to any issue because the deployment would then simply do nothing. Still, it would be better to catch that kind of errors.