### PR TITLE
Switch to new Cachix instance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           name: tweag-plutus-libs
           ## This auth token will give write access to the cache, meaning that
           ## everything that happens in CI will be pushed at the end of the job.
-          authToken: '${{ secrets.CACHIX_TWEAG_PLUTUS_LIBS_AUTH_TOKEN }}'
+          authToken: '${{ secrets.CACHIX_TWEAG_COOKED_VALIDATORS_AUTH_TOKEN }}'
 
       - name: Build Nix CI environment
         run: |
@@ -64,7 +64,7 @@ jobs:
           name: tweag-plutus-libs
           ## This auth token will give write access to the cache, meaning that
           ## everything that happens in CI will be pushed at the end of the job.
-          authToken: '${{ secrets.CACHIX_TWEAG_PLUTUS_LIBS_AUTH_TOKEN }}'
+          authToken: '${{ secrets.CACHIX_TWEAG_COOKED_VALIDATORS_AUTH_TOKEN }}'
 
       - name: Build all Nix environments
         run: |
@@ -301,7 +301,7 @@ jobs:
           name: tweag-plutus-libs
           ## This auth token will give write access to the cache, meaning that
           ## everything that happens in CI will be pushed at the end of the job.
-          authToken: '${{ secrets.CACHIX_TWEAG_PLUTUS_LIBS_AUTH_TOKEN }}'
+          authToken: '${{ secrets.CACHIX_TWEAG_COOKED_VALIDATORS_AUTH_TOKEN }}'
 
       - name: Run flake checks
         run: nix flake check --print-build-logs

--- a/flake.nix
+++ b/flake.nix
@@ -67,9 +67,10 @@
       });
 
   nixConfig = {
-    extra-trusted-substituters = [ "https://tweag-plutus-libs.cachix.org/" ];
+    extra-trusted-substituters =
+      [ "https://tweag-cooked-validators.cachix.org/" ];
     extra-trusted-public-keys = [
-      "tweag-plutus-libs.cachix.org-1:0BeVJYx8DnUWJWapRDZeLPOOboBUy3UwhvONd5Qm2Xc="
+      "tweag-cooked-validators.cachix.org-1:g1TP7YtXjkBGXP/VbSTGBOGONSzdfzYwNJM27bn8pik="
     ];
   };
 }


### PR DESCRIPTION
This PR makes the switch from [the old cachix instance](https://app.cachix.org/cache/tweag-plutus-libs) to [the new one](https://app.cachix.org/cache/tweag-cooked-validators). The renaming shouldn't change much but should make it less surprising for users. The CI should take forever because we need to populate the new cache. Actually, I am expecting a failure because Ormolu is too big to build on the GitHub Action runners.