### PR TITLE
Add a tweak to help malform datums

### DIFF
--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -123,6 +123,7 @@ test-suite spec
       Cooked.TestUtils
       Cooked.Tweak.CommonSpec
       Cooked.Tweak.OutPermutationsSpec
+      Cooked.Tweak.TamperDatumSpec
       Cooked.Tweak.ValidityRangeSpec
       Cooked.TweakSpec
       Paths_cooked_validators

--- a/src/Cooked/Pretty/Class.hs
+++ b/src/Cooked/Pretty/Class.hs
@@ -164,3 +164,6 @@ instance PrettyCooked Bool where
 
 instance PrettyCooked () where
   prettyCookedOpt _ = PP.pretty
+
+instance PrettyCooked Pl.BuiltinData where
+  prettyCookedOpt _ = PP.pretty

--- a/src/Cooked/Tweak/TamperDatum.hs
+++ b/src/Cooked/Tweak/TamperDatum.hs
@@ -85,6 +85,8 @@ malformDatumTweak ::
 malformDatumTweak change = do
   outputs <- viewAllTweak (txSkelOutsL % traversed)
   let modifiedOutputs = map (\output -> output : changeOutput output) outputs
+      -- We remove the first combination because it consists of all the heads
+      -- and therefore it is the combination consisting of no changes at all.
       modifiedOutputGroups = tail $ allCombinations modifiedOutputs
   msum $ map (setTweak txSkelOutsL) modifiedOutputGroups
   addLabelTweak MalformDatumLbl
@@ -126,12 +128,15 @@ data MalformDatumLbl = MalformDatumLbl deriving (Show, Eq, Ord)
 --
 -- @allCombinations [[1,2,3], [4,5], [6]] == [[1,4,6], [1,5,6], [2,4,6], [2,5,6], [3,4,6], [3,5,6]]@
 --
--- It is guaranteed that combinations are returned in such an order that @c1@ comes before @c2@ in the result list
--- if and only if for some @p, a1, r1, a2, r2@
+-- It is guaranteed that combinations are returned in such an order that a
+-- combination @c1@ comes before a combination @c2@ in the result list if and
+-- only if for some prefix list @p@, some elements @a1@ and @a2@ and for some
+-- rest lists @r1@ and @r2@:
 -- > c1 == p ++ (a1 : r1)
 -- > c2 == p ++ (a2 : r2)
--- and @a1@ comes before @a2@ in the list @l !! (length p -1)@. In particular, the first element of the result list is
--- the list consisting of all the first elements of the input lists.
+-- and @a1@ comes before @a2@ in the list @l !! length p@. In particular, the
+-- first element of the result list is the combination consisting of all the
+-- first elements of the input lists.
 allCombinations :: [[a]] -> [[a]]
 allCombinations [] = [[]]
 allCombinations [[]] = [] -- included in the next one

--- a/src/Cooked/Tweak/TamperDatum.hs
+++ b/src/Cooked/Tweak/TamperDatum.hs
@@ -71,6 +71,7 @@ malformDatumTweak change = do
   let modifiedOutputs = map (\output -> output : changeOutput output) outputs
       modifiedOutputGroups = tail $ allCombinations modifiedOutputs
   msum $ map (setTweak txSkelOutsL) modifiedOutputGroups
+  addLabelTweak MalformDatumLbl
   where
     changeOutput :: TxSkelOut -> [TxSkelOut]
     changeOutput (Pays out) =

--- a/src/Cooked/Tweak/TamperDatum.hs
+++ b/src/Cooked/Tweak/TamperDatum.hs
@@ -23,8 +23,8 @@ import Optics.Core
 import qualified PlutusTx as Pl
 import Type.Reflection
 
--- | A tweak that tries to change the datum on outputs that go to scripts with a
--- prescribed tampering function, that only applies to datums of a certain type.
+-- | A tweak that tries to change the datum on outputs carrying datums of a
+-- certain type with a prescribed tampering function.
 --
 -- The tweak returns a list of the modified datums, as they were *before* the
 -- modification was applied to them.
@@ -56,7 +56,12 @@ tamperDatumTweak change = do
 
 data TamperDatumLbl = TamperDatumLbl deriving (Show, Eq, Ord)
 
--- | FIXME
+-- | A tweak that tries to change the datum on outputs carrying datums of a
+-- certain type with a prescribed tampering function. There are two main
+-- differences with 'tamperDatumTweak'. First, the tampering function can return
+-- several tampered datums, and it returns the as 'BuiltinData', allowing it to
+-- do pretty much anything with them. Second, the modifications are applied to
+-- all outputs but also to all subsets of these outputs (except the empty set).
 malformDatumTweak ::
   forall a m.
   ( MonadTweak m,
@@ -101,12 +106,21 @@ malformDatumTweak change = do
 
 data MalformDatumLbl = MalformDatumLbl deriving (Show, Eq, Ord)
 
--- | FIXME: document
+-- | Given a list of lists, we call “combination” a list of the same size as the
+-- outer list consisting of one element of each of the inner lists. More
+-- formally, @c@ is a combination of @l@ if @length c == length l@ and for all
+-- @0 <= i < length c@, @elem (c !! i) (l !! i)@.
 --
--- The first element of the result is the list consisting of all the first
--- elements of the inputs.
+-- 'allCombinations', as the name suggests, returns all the possible
+-- combinations of a given list of lists. For instance:
 --
 -- @allCombinations [[1,2,3], [4,5], [6]] == [[1,4,6], [1,5,6], [2,4,6], [2,5,6], [3,4,6], [3,5,6]]@
+--
+-- It is guaranteed that the first element of the result is the list consisting
+-- of all the first elements of the inputs.
+--
+-- REVIEW: The guarantee can be much better and probably expressed in term of
+-- lexicographic order or whatnot.
 allCombinations :: [[a]] -> [[a]]
 allCombinations [] = [[]]
 allCombinations [[]] = [] -- included in the next one

--- a/src/Cooked/Tweak/TamperDatum.hs
+++ b/src/Cooked/Tweak/TamperDatum.hs
@@ -8,10 +8,13 @@
 module Cooked.Tweak.TamperDatum
   ( tamperDatumTweak,
     TamperDatumLbl (..),
+    malformDatumTweak,
+    MalformDatumLbl (..),
   )
 where
 
 import Control.Monad
+import Cooked.Output
 import Cooked.Pretty.Class
 import Cooked.Skeleton
 import Cooked.Tweak.Common
@@ -52,3 +55,58 @@ tamperDatumTweak change = do
   return beforeModification
 
 data TamperDatumLbl = TamperDatumLbl deriving (Show, Eq, Ord)
+
+-- | FIXME
+malformDatumTweak ::
+  forall a m.
+  ( MonadTweak m,
+    Pl.ToData a,
+    Pl.FromData a,
+    Typeable a
+  ) =>
+  (a -> [Pl.BuiltinData]) ->
+  m ()
+malformDatumTweak change = do
+  outputs <- viewAllTweak (txSkelOutsL % traversed)
+  let modifiedOutputs = map (\output -> output : changeOutput output) outputs
+      modifiedOutputGroups = tail $ allCombinations modifiedOutputs
+  msum $ map (setTweak txSkelOutsL) modifiedOutputGroups
+  where
+    changeOutput :: TxSkelOut -> [TxSkelOut]
+    changeOutput (Pays out) =
+      let datums = changeTxSkelOutDatum $ view outputDatumL out
+       in map
+            ( \datum ->
+                Pays $
+                  ConcreteOutput
+                    (out ^. outputOwnerL)
+                    (out ^. outputStakingCredentialL)
+                    (out ^. outputValueL)
+                    datum
+                    (out ^. outputReferenceScriptL)
+            )
+            datums
+
+    changeTxSkelOutDatum :: TxSkelOutDatum -> [TxSkelOutDatum]
+    changeTxSkelOutDatum TxSkelOutNoDatum = []
+    changeTxSkelOutDatum (TxSkelOutDatum datum) = map TxSkelOutDatum $ changeOnCorrectType datum
+    changeTxSkelOutDatum (TxSkelOutDatumHash datum) = map TxSkelOutDatumHash $ changeOnCorrectType datum
+    changeTxSkelOutDatum (TxSkelOutInlineDatum datum) = map TxSkelOutInlineDatum $ changeOnCorrectType datum
+
+    changeOnCorrectType :: Typeable b => b -> [Pl.BuiltinData]
+    changeOnCorrectType datum = case typeOf datum `eqTypeRep` (typeRep @a) of
+      Just HRefl -> change datum
+      Nothing -> []
+
+data MalformDatumLbl = MalformDatumLbl deriving (Show, Eq, Ord)
+
+-- | FIXME: document
+--
+-- The first element of the result is the list consisting of all the first
+-- elements of the inputs.
+--
+-- @allCombinations [[1,2,3], [4,5], [6]] == [[1,4,6], [1,5,6], [2,4,6], [2,5,6], [3,4,6], [3,5,6]]@
+allCombinations :: [[a]] -> [[a]]
+allCombinations [] = [[]]
+allCombinations [[]] = [] -- included in the next one
+allCombinations (first : rest) = [x : xs | x <- first, xs <- allCombinations rest]

--- a/tests/Cooked/TestUtils.hs
+++ b/tests/Cooked/TestUtils.hs
@@ -29,4 +29,9 @@ assertSubset l r =
     )
 
 assertSameSets :: (Show a, Eq a) => [a] -> [a] -> Assertion
-assertSameSets l r = (length l @?= length r) .&&. assertSubset l r .&&. assertSubset r l
+assertSameSets l r =
+  assertBool
+    ("expected lists of the same length, got " ++ show (length l) ++ " and " ++ show (length r))
+    (length l == length r)
+    .&&. assertSubset l r
+    .&&. assertSubset r l

--- a/tests/Cooked/Tweak/TamperDatumSpec.hs
+++ b/tests/Cooked/Tweak/TamperDatumSpec.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeApplications #-}
+
+--
+
+module Cooked.Tweak.TamperDatumSpec where
+
+import Cooked
+import Cooked.MockChain.Staged (runTweak)
+import qualified Data.Set as Set
+import qualified Plutus.Script.Utils.Ada as Pl
+import Prettyprinter (viaShow)
+import Test.Tasty
+import Test.Tasty.HUnit
+
+instance PrettyCooked (Integer, Integer) where
+  prettyCookedOpt _ = viaShow
+
+tests :: TestTree
+tests =
+  testGroup
+    "Tamper datum tweaks"
+    ( let skel =
+            txSkelTemplate
+              { txSkelOuts =
+                  [ paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 789) `withDatum` (52 :: Integer, 53 :: Integer),
+                    paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 234) `withDatum` (),
+                    paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` (76 :: Integer, 77 :: Integer)
+                  ]
+              }
+       in [ testCase "tamperDatumTweak" $
+              [ Right
+                  ( [ (52, 53),
+                      (76, 77)
+                    ],
+                    txSkelTemplate
+                      { txSkelLabel = Set.singleton $ TxLabel TamperDatumLbl,
+                        txSkelOuts =
+                          [ paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 789) `withDatum` (52 :: Integer, 54 :: Integer),
+                            paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 234) `withDatum` (),
+                            paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` (76 :: Integer, 78 :: Integer)
+                          ]
+                      }
+                  )
+              ]
+                @=? runTweak
+                  ( tamperDatumTweak @(Integer, Integer)
+                      (\(x, y) -> Just (x, y + 1))
+                  )
+                  skel
+          ]
+    )

--- a/tests/Cooked/Tweak/TamperDatumSpec.hs
+++ b/tests/Cooked/Tweak/TamperDatumSpec.hs
@@ -7,8 +7,10 @@ module Cooked.Tweak.TamperDatumSpec where
 
 import Cooked
 import Cooked.MockChain.Staged (runTweak)
+import Cooked.TestUtils (assertSameSets)
 import qualified Data.Set as Set
 import qualified Plutus.Script.Utils.Ada as Pl
+import qualified PlutusTx
 import Prettyprinter (viaShow)
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -20,33 +22,75 @@ tests :: TestTree
 tests =
   testGroup
     "Tamper datum tweaks"
-    ( let skel =
-            txSkelTemplate
-              { txSkelOuts =
-                  [ paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 789) `withDatum` (52 :: Integer, 53 :: Integer),
-                    paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 234) `withDatum` (),
-                    paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` (76 :: Integer, 77 :: Integer)
-                  ]
-              }
-       in [ testCase "tamperDatumTweak" $
-              [ Right
-                  ( [ (52, 53),
-                      (76, 77)
-                    ],
-                    txSkelTemplate
-                      { txSkelLabel = Set.singleton $ TxLabel TamperDatumLbl,
-                        txSkelOuts =
-                          [ paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 789) `withDatum` (52 :: Integer, 54 :: Integer),
+    [ testCase "tamperDatumTweak" $
+        [ Right
+            ( [(52, 53)],
+              txSkelTemplate
+                { txSkelLabel = Set.singleton $ TxLabel TamperDatumLbl,
+                  txSkelOuts =
+                    [ paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 789) `withDatum` (52 :: Integer, 54 :: Integer),
+                      paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 234) `withDatum` (),
+                      paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` (76 :: Integer, 77 :: Integer)
+                    ]
+                }
+            )
+        ]
+          @=? runTweak
+            ( tamperDatumTweak @(Integer, Integer)
+                (\(x, y) -> if y == 77 then Nothing else Just (x, y + 1))
+            )
+            ( txSkelTemplate
+                { txSkelOuts =
+                    [ paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 789) `withDatum` (52 :: Integer, 53 :: Integer),
+                      paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 234) `withDatum` (),
+                      paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` (76 :: Integer, 77 :: Integer)
+                    ]
+                }
+            ),
+      testCase "malformDatumTweak" $
+        let txSkelWithDatums1And4 :: (PlutusTx.ToData a, PlutusTx.ToData b) => a -> b -> Either MockChainError ((), TxSkel)
+            txSkelWithDatums1And4 datum1 datum4 =
+              Right
+                ( (),
+                  txSkelTemplate
+                    { txSkelLabel = Set.singleton $ TxLabel MalformDatumLbl,
+                      txSkelOuts =
+                        [ paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 789) `withDatum` PlutusTx.toBuiltinData datum1,
+                          paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 234) `withDatum` (),
+                          paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` (76 :: Integer, 77 :: Integer),
+                          paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` PlutusTx.toBuiltinData datum4
+                        ]
+                    }
+                )
+         in assertSameSets
+              [ txSkelWithDatums1And4 (52 :: Integer, ()) (84 :: Integer, 85 :: Integer),
+                txSkelWithDatums1And4 False (84 :: Integer, 85 :: Integer),
+                txSkelWithDatums1And4 (52 :: Integer, ()) (84 :: Integer, ()),
+                txSkelWithDatums1And4 False False,
+                txSkelWithDatums1And4 (52 :: Integer, ()) False,
+                txSkelWithDatums1And4 False (84 :: Integer, ()),
+                txSkelWithDatums1And4 (52 :: Integer, 53 :: Integer) (84 :: Integer, ()),
+                txSkelWithDatums1And4 (52 :: Integer, 53 :: Integer) False
+              ]
+              ( runTweak
+                  ( malformDatumTweak @(Integer, Integer)
+                      ( \(x, y) ->
+                          if y == 77
+                            then []
+                            else
+                              [ PlutusTx.toBuiltinData (x, ()),
+                                PlutusTx.toBuiltinData False
+                              ]
+                      )
+                  )
+                  ( txSkelTemplate
+                      { txSkelOuts =
+                          [ paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 789) `withDatum` (52 :: Integer, 53 :: Integer),
                             paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 234) `withDatum` (),
-                            paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` (76 :: Integer, 78 :: Integer)
+                            paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` (76 :: Integer, 77 :: Integer),
+                            paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` (84 :: Integer, 85 :: Integer)
                           ]
                       }
                   )
-              ]
-                @=? runTweak
-                  ( tamperDatumTweak @(Integer, Integer)
-                      (\(x, y) -> Just (x, y + 1))
-                  )
-                  skel
-          ]
-    )
+              )
+    ]

--- a/tests/Cooked/Tweak/TamperDatumSpec.hs
+++ b/tests/Cooked/Tweak/TamperDatumSpec.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeApplications #-}
 
---
-
+-- | Tests for 'Cooked.Tweak.TamperDatum'.
 module Cooked.Tweak.TamperDatumSpec where
 
 import Cooked
@@ -12,85 +11,91 @@ import qualified Data.Set as Set
 import qualified Plutus.Script.Utils.Ada as Pl
 import qualified PlutusTx
 import Prettyprinter (viaShow)
-import Test.Tasty
-import Test.Tasty.HUnit
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@=?))
 
 instance PrettyCooked (Integer, Integer) where
   prettyCookedOpt _ = viaShow
+
+tamperDatumTweakTest =
+  testCase "tamperDatumTweak" $
+    [ Right
+        ( [(52, 53)],
+          txSkelTemplate
+            { txSkelLabel = Set.singleton $ TxLabel TamperDatumLbl,
+              txSkelOuts =
+                [ paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 789) `withDatum` (52 :: Integer, 54 :: Integer),
+                  paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 234) `withDatum` (),
+                  paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` (76 :: Integer, 77 :: Integer)
+                ]
+            }
+        )
+    ]
+      @=? runTweak
+        ( tamperDatumTweak @(Integer, Integer)
+            (\(x, y) -> if y == 77 then Nothing else Just (x, y + 1))
+        )
+        ( txSkelTemplate
+            { txSkelOuts =
+                [ paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 789) `withDatum` (52 :: Integer, 53 :: Integer),
+                  paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 234) `withDatum` (),
+                  paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` (76 :: Integer, 77 :: Integer)
+                ]
+            }
+        )
+
+malformDatumTweakTest =
+  testCase "malformDatumTweak" $
+    let txSkelWithDatums1And4 :: (PlutusTx.ToData a, PlutusTx.ToData b) => a -> b -> Either MockChainError ((), TxSkel)
+        txSkelWithDatums1And4 datum1 datum4 =
+          Right
+            ( (),
+              txSkelTemplate
+                { txSkelLabel = Set.singleton $ TxLabel MalformDatumLbl,
+                  txSkelOuts =
+                    [ paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 789) `withDatum` PlutusTx.toBuiltinData datum1,
+                      paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 234) `withDatum` (),
+                      paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` (76 :: Integer, 77 :: Integer),
+                      paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` PlutusTx.toBuiltinData datum4
+                    ]
+                }
+            )
+     in assertSameSets
+          [ txSkelWithDatums1And4 (52 :: Integer, ()) (84 :: Integer, 85 :: Integer), -- datum1 changed, datum4 untouched
+            txSkelWithDatums1And4 False (84 :: Integer, 85 :: Integer), -- datum1 changed, datum4 untouched
+            txSkelWithDatums1And4 (52 :: Integer, ()) (84 :: Integer, ()), -- datum1 changed, datum4 as well
+            txSkelWithDatums1And4 False False, -- datum1 changed, datum4 as well
+            txSkelWithDatums1And4 (52 :: Integer, ()) False, -- datum1 changed, datum4 as well
+            txSkelWithDatums1And4 False (84 :: Integer, ()), -- datum1 changed, datum4 as well
+            txSkelWithDatums1And4 (52 :: Integer, 53 :: Integer) (84 :: Integer, ()), -- datum1 untouched, datum4 changed
+            txSkelWithDatums1And4 (52 :: Integer, 53 :: Integer) False -- datum1 untouched, datum4 changed
+          ]
+          ( runTweak
+              ( malformDatumTweak @(Integer, Integer)
+                  ( \(x, y) ->
+                      if y == 77
+                        then []
+                        else
+                          [ PlutusTx.toBuiltinData (x, ()),
+                            PlutusTx.toBuiltinData False
+                          ]
+                  )
+              )
+              ( txSkelTemplate
+                  { txSkelOuts =
+                      [ paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 789) `withDatum` (52 :: Integer, 53 :: Integer),
+                        paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 234) `withDatum` (),
+                        paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` (76 :: Integer, 77 :: Integer),
+                        paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` (84 :: Integer, 85 :: Integer)
+                      ]
+                  }
+              )
+          )
 
 tests :: TestTree
 tests =
   testGroup
     "Tamper datum tweaks"
-    [ testCase "tamperDatumTweak" $
-        [ Right
-            ( [(52, 53)],
-              txSkelTemplate
-                { txSkelLabel = Set.singleton $ TxLabel TamperDatumLbl,
-                  txSkelOuts =
-                    [ paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 789) `withDatum` (52 :: Integer, 54 :: Integer),
-                      paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 234) `withDatum` (),
-                      paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` (76 :: Integer, 77 :: Integer)
-                    ]
-                }
-            )
-        ]
-          @=? runTweak
-            ( tamperDatumTweak @(Integer, Integer)
-                (\(x, y) -> if y == 77 then Nothing else Just (x, y + 1))
-            )
-            ( txSkelTemplate
-                { txSkelOuts =
-                    [ paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 789) `withDatum` (52 :: Integer, 53 :: Integer),
-                      paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 234) `withDatum` (),
-                      paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` (76 :: Integer, 77 :: Integer)
-                    ]
-                }
-            ),
-      testCase "malformDatumTweak" $
-        let txSkelWithDatums1And4 :: (PlutusTx.ToData a, PlutusTx.ToData b) => a -> b -> Either MockChainError ((), TxSkel)
-            txSkelWithDatums1And4 datum1 datum4 =
-              Right
-                ( (),
-                  txSkelTemplate
-                    { txSkelLabel = Set.singleton $ TxLabel MalformDatumLbl,
-                      txSkelOuts =
-                        [ paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 789) `withDatum` PlutusTx.toBuiltinData datum1,
-                          paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 234) `withDatum` (),
-                          paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` (76 :: Integer, 77 :: Integer),
-                          paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` PlutusTx.toBuiltinData datum4
-                        ]
-                    }
-                )
-         in assertSameSets
-              [ txSkelWithDatums1And4 (52 :: Integer, ()) (84 :: Integer, 85 :: Integer),
-                txSkelWithDatums1And4 False (84 :: Integer, 85 :: Integer),
-                txSkelWithDatums1And4 (52 :: Integer, ()) (84 :: Integer, ()),
-                txSkelWithDatums1And4 False False,
-                txSkelWithDatums1And4 (52 :: Integer, ()) False,
-                txSkelWithDatums1And4 False (84 :: Integer, ()),
-                txSkelWithDatums1And4 (52 :: Integer, 53 :: Integer) (84 :: Integer, ()),
-                txSkelWithDatums1And4 (52 :: Integer, 53 :: Integer) False
-              ]
-              ( runTweak
-                  ( malformDatumTweak @(Integer, Integer)
-                      ( \(x, y) ->
-                          if y == 77
-                            then []
-                            else
-                              [ PlutusTx.toBuiltinData (x, ()),
-                                PlutusTx.toBuiltinData False
-                              ]
-                      )
-                  )
-                  ( txSkelTemplate
-                      { txSkelOuts =
-                          [ paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 789) `withDatum` (52 :: Integer, 53 :: Integer),
-                            paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 234) `withDatum` (),
-                            paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` (76 :: Integer, 77 :: Integer),
-                            paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 567) `withDatum` (84 :: Integer, 85 :: Integer)
-                          ]
-                      }
-                  )
-              )
+    [ tamperDatumTweakTest,
+      malformDatumTweakTest
     ]

--- a/tests/Cooked/TweakSpec.hs
+++ b/tests/Cooked/TweakSpec.hs
@@ -2,6 +2,7 @@ module Cooked.TweakSpec (tests) where
 
 import qualified Cooked.Tweak.CommonSpec as CommonSpec
 import qualified Cooked.Tweak.OutPermutationsSpec as OutPermutationsSpec
+import qualified Cooked.Tweak.TamperDatumSpec as TamperDatumSpec
 import qualified Cooked.Tweak.ValidityRangeSpec as ValidityRangeSpec
 import Test.Tasty
 
@@ -11,5 +12,6 @@ tests =
     "Tweaks"
     [ CommonSpec.tests,
       OutPermutationsSpec.tests,
+      TamperDatumSpec.tests,
       ValidityRangeSpec.tests
     ]


### PR DESCRIPTION
This PR is joint work with @carlhammann. It adds a tweak `malformDatumTweak` as well as a test for it. Since it is pretty close to the existing `tamperDatumTweak`, it goes live in the same module, and we add a test for that one too. (There might be some work to make on better naming, but I am out of ideas.)