### PR TITLE
Align tooling used by pre-commit hooks/CI and `nix develop`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+## .git-blame-ignore-revs
+
+## run ormolu & hpack
+550c27cff4e96e8726bfe2a256971d9024625726

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 

--- a/flake.lock
+++ b/flake.lock
@@ -98,28 +98,14 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1671271357,
-        "narHash": "sha256-xRJdLbWK4v2SewmSStYrcLa0YGJpleufl44A19XSW8k=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "40f79f003b6377bd2f4ed4027dde1f8f922995dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils_2",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,10 @@
             ## `nixpkgs`, then we can simply make sure that
             ## `pre-commit-hooks.nix`'s `nixpkgs` input follows ours, so there
             ## is nothing to see here.
+            ##
+            ## NOTE: Configuring `hpack` here would have no effect. See
+            ## https://github.com/cachix/pre-commit-hooks.nix/issues/255
+            ## for more information.
           };
         };
       in {

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,7 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
+  inputs.pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs = { self, nixpkgs, flake-utils, pre-commit-hooks }:
     flake-utils.lib.eachDefaultSystem (system:
@@ -15,6 +16,13 @@
             nixfmt.enable = true;
             ormolu.enable = true;
             hpack.enable = true;
+          };
+          tools = {
+            ## This setting specifies which tools to use in the `pre-commit`
+            ## hooks. Since we take our tools (`nixfmt`, `ormolu`, `hpack`) from
+            ## `nixpkgs`, then we can simply make sure that
+            ## `pre-commit-hooks.nix`'s `nixpkgs` input follows ours, so there
+            ## is nothing to see here.
           };
         };
       in {

--- a/src/Cooked/MockChain/Balancing.hs
+++ b/src/Cooked/MockChain/Balancing.hs
@@ -281,16 +281,16 @@ setFeeAndBalance balanceWallet skel0 = do
         Left err -> throwError $ MCECalcFee err
         Right newFee
           | newFee == fee -> do
-            -- Debug.Trace.traceM "Reached fixpoint:"
-            -- Debug.Trace.traceM $ "- fee = " <> show fee
-            -- Debug.Trace.traceM $ "- skeleton = " <> show (attemptedSkel {_txSkelFee = fee})
-            pure (attemptedSkel, fee) -- reached fixpoint
+              -- Debug.Trace.traceM "Reached fixpoint:"
+              -- Debug.Trace.traceM $ "- fee = " <> show fee
+              -- Debug.Trace.traceM $ "- skeleton = " <> show (attemptedSkel {_txSkelFee = fee})
+              pure (attemptedSkel, fee) -- reached fixpoint
           | n == 0 -> do
-            -- Debug.Trace.traceM $ "Max iteration reached: newFee = " <> show newFee
-            pure (attemptedSkel, max newFee fee) -- maximum number of iterations
+              -- Debug.Trace.traceM $ "Max iteration reached: newFee = " <> show newFee
+              pure (attemptedSkel, max newFee fee) -- maximum number of iterations
           | otherwise -> do
-            -- Debug.Trace.traceM $ "New iteration: newfee = " <> show newFee
-            calcFee (n - 1) newFee cUtxoIndex skel
+              -- Debug.Trace.traceM $ "New iteration: newfee = " <> show newFee
+              calcFee (n - 1) newFee cUtxoIndex skel
 
 -- | This funcion is essentially a copy of
 -- https://github.com/input-output-hk/plutus-apps/blob/d4255f05477fd8477ee9673e850ebb9ebb8c9657/plutus-ledger/src/Ledger/Fee.hs#L19

--- a/src/Cooked/MockChain/GenerateTx.hs
+++ b/src/Cooked/MockChain/GenerateTx.hs
@@ -289,8 +289,8 @@ generateTxBodyContent GenTxParams {..} theParams managedData managedTxOuts manag
 
         witnessMap :: Either GenerateTxError (Map C.PolicyId (C.ScriptWitness C.WitCtxMint C.BabbageEra))
         witnessMap =
-          right mconcat $
-            mapM
+          right mconcat
+            $ mapM
               ( \(policy, redeemer, _tName, _amount) ->
                   Map.singleton
                     <$> left
@@ -298,7 +298,7 @@ generateTxBodyContent GenTxParams {..} theParams managedData managedTxOuts manag
                       (Pl.toCardanoPolicyId (Pl.mintingPolicyHash policy))
                     <*> mkMintWitness policy redeemer
               )
-              $ txSkelMintsToList mints
+            $ txSkelMintsToList mints
 
         mkMintWitness ::
           Pl.Versioned Pl.MintingPolicy ->

--- a/src/Cooked/Pretty/Cooked.hs
+++ b/src/Cooked/Pretty/Cooked.hs
@@ -176,13 +176,13 @@ instance PrettyCooked MockChainLog where
             : entries
           )
           | pcOptPrintTxHashes opts =
-            go
-              ( "Validated"
-                  <+> PP.parens ("TxId:" <+> prettyCookedOpt opts txId)
-                  <+> prettyTxSkel opts skelContext skel :
-                acc
-              )
-              entries
+              go
+                ( "Validated"
+                    <+> PP.parens ("TxId:" <+> prettyCookedOpt opts txId)
+                    <+> prettyTxSkel opts skelContext skel
+                    : acc
+                )
+                entries
           | otherwise = go ("Validated" <+> prettyTxSkel opts skelContext skel : acc) entries
       go
         acc
@@ -262,22 +262,22 @@ prettyTxSkelOut opts (Pays output) =
   prettyItemize
     ("Pays to" <+> prettyCookedOpt opts (outputAddress output))
     "-"
-    ( prettyCookedOpt opts (outputValue output) :
-      catMaybes
-        [ case outputOutputDatum output of
-            Pl.OutputDatum _datum ->
-              Just $
-                "Datum (inlined):"
-                  <+> (PP.align . prettyCookedOpt opts)
-                    (output ^. outputDatumL)
-            Pl.OutputDatumHash _datum ->
-              Just $
-                "Datum (hashed):"
-                  <+> (PP.align . prettyCookedOpt opts)
-                    (output ^. outputDatumL)
-            Pl.NoOutputDatum -> Nothing,
-          getReferenceScriptDoc opts output
-        ]
+    ( prettyCookedOpt opts (outputValue output)
+        : catMaybes
+          [ case outputOutputDatum output of
+              Pl.OutputDatum _datum ->
+                Just $
+                  "Datum (inlined):"
+                    <+> (PP.align . prettyCookedOpt opts)
+                      (output ^. outputDatumL)
+              Pl.OutputDatumHash _datum ->
+                Just $
+                  "Datum (hashed):"
+                    <+> (PP.align . prettyCookedOpt opts)
+                      (output ^. outputDatumL)
+              Pl.NoOutputDatum -> Nothing,
+            getReferenceScriptDoc opts output
+          ]
     )
 
 prettyTxSkelOutDatumMaybe :: PrettyCookedOpts -> TxSkelOutDatum -> Maybe DocCooked
@@ -302,12 +302,12 @@ prettyTxSkelIn opts skelContext (txOutRef, txSkelRedeemer) = do
     prettyItemize
       ("Spends from" <+> prettyCookedOpt opts (outputAddress output))
       "-"
-      ( prettyCookedOpt opts (outputValue output) :
-        catMaybes
-          [ redeemerDoc,
-            prettyTxSkelOutDatumMaybe opts txSkelOutDatum,
-            getReferenceScriptDoc opts output
-          ]
+      ( prettyCookedOpt opts (outputValue output)
+          : catMaybes
+            [ redeemerDoc,
+              prettyTxSkelOutDatumMaybe opts txSkelOutDatum,
+              getReferenceScriptDoc opts output
+            ]
       )
 
 prettyTxSkelInReference :: PrettyCookedOpts -> SkelContext -> Pl.TxOutRef -> Maybe DocCooked
@@ -317,11 +317,11 @@ prettyTxSkelInReference opts skelContext txOutRef = do
     prettyItemize
       ("References output from" <+> prettyCookedOpt opts (outputAddress output))
       "-"
-      ( prettyCookedOpt opts (outputValue output) :
-        catMaybes
-          [ prettyTxSkelOutDatumMaybe opts txSkelOutDatum,
-            getReferenceScriptDoc opts output
-          ]
+      ( prettyCookedOpt opts (outputValue output)
+          : catMaybes
+            [ prettyTxSkelOutDatumMaybe opts txSkelOutDatum,
+              getReferenceScriptDoc opts output
+            ]
       )
 
 getReferenceScriptDoc :: (IsAbstractOutput output, ToScriptHash (ReferenceScriptType output)) => PrettyCookedOpts -> output -> Maybe DocCooked

--- a/src/Cooked/ShowBS.hs
+++ b/src/Cooked/ShowBS.hs
@@ -178,8 +178,8 @@ builtinByteStringCharacters s = go (len - 1) []
     go :: Integer -> [BuiltinString] -> [BuiltinString]
     go i acc
       | i >= 0 =
-        let (highNibble, lowNibble) = quotRem (indexByteString s i) 16
-         in go (i - 1) (toHex highNibble : toHex lowNibble : acc)
+          let (highNibble, lowNibble) = quotRem (indexByteString s i) 16
+           in go (i - 1) (toHex highNibble : toHex lowNibble : acc)
       | otherwise = acc
 
     toHex :: Integer -> BuiltinString

--- a/src/Cooked/Skeleton.hs
+++ b/src/Cooked/Skeleton.hs
@@ -379,32 +379,32 @@ addToTxSkelMints ::
 addToTxSkelMints (pol, red, tName, amount) mints
   | 0 == amount = mints
   | otherwise = case mints Map.!? pol of
-    Nothing ->
-      -- The policy isn't yet in the given 'TxSkelMints', so we can just add a
-      -- new entry:
-      Map.insert pol (red, NEMap.singleton tName (NonZero amount)) mints
-    Just (_oldRed, innerMap) ->
-      -- Ignore the old redeemer: If it's the same as the new one, nothing will
-      -- change, if not, the new redeemer will be kept.
-      case innerMap NEMap.!? tName of
-        Nothing ->
-          -- The given token name has not yet occurred for the given
-          -- policy. This means that we can just add the new tokens to the
-          -- inner map:
-          Map.insert pol (red, NEMap.insert tName (NonZero amount) innerMap) mints
-        Just (NonZero oldAmount) ->
-          let newAmount = oldAmount + amount
-           in if newAmount /= 0
-                then -- If the sum of the old amount of tokens and the additional
-                -- tokens is non-zero, we can just update the amount in the
-                -- inner map:
-                  Map.insert pol (red, NEMap.insert tName (NonZero newAmount) innerMap) mints
-                else -- If the sum is zero, we'll have to delete the token name
-                -- from the inner map. If that yields a completely empty
-                -- inner map, we'll have to remove the entry altogether:
-                case NEMap.nonEmptyMap $ NEMap.delete tName innerMap of
-                  Nothing -> Map.delete pol mints
-                  Just newInnerMap -> Map.insert pol (red, newInnerMap) mints
+      Nothing ->
+        -- The policy isn't yet in the given 'TxSkelMints', so we can just add a
+        -- new entry:
+        Map.insert pol (red, NEMap.singleton tName (NonZero amount)) mints
+      Just (_oldRed, innerMap) ->
+        -- Ignore the old redeemer: If it's the same as the new one, nothing will
+        -- change, if not, the new redeemer will be kept.
+        case innerMap NEMap.!? tName of
+          Nothing ->
+            -- The given token name has not yet occurred for the given
+            -- policy. This means that we can just add the new tokens to the
+            -- inner map:
+            Map.insert pol (red, NEMap.insert tName (NonZero amount) innerMap) mints
+          Just (NonZero oldAmount) ->
+            let newAmount = oldAmount + amount
+             in if newAmount /= 0
+                  then -- If the sum of the old amount of tokens and the additional
+                  -- tokens is non-zero, we can just update the amount in the
+                  -- inner map:
+                    Map.insert pol (red, NEMap.insert tName (NonZero newAmount) innerMap) mints
+                  else -- If the sum is zero, we'll have to delete the token name
+                  -- from the inner map. If that yields a completely empty
+                  -- inner map, we'll have to remove the entry altogether:
+                  case NEMap.nonEmptyMap $ NEMap.delete tName innerMap of
+                    Nothing -> Map.delete pol mints
+                    Just newInnerMap -> Map.insert pol (red, newInnerMap) mints
 
 -- | Convert from 'TxSkelMints' to a list of tuples describing eveything that's
 -- being minted.

--- a/tests/Cooked/Attack/DoubleSatSpec.hs
+++ b/tests/Cooked/Attack/DoubleSatSpec.hs
@@ -183,32 +183,32 @@ tests =
                                 Just aValue <- valueFromTxOutRef aOref
                                 if
                                     | aValue == Pl.lovelaceValueOf 2_000_000 ->
-                                      return
-                                        [ toDelta bOref $ TxSkelRedeemerForScript BRedeemer1
-                                          | (bOref, bOut) <- bUtxos,
-                                            outputValue bOut == Pl.lovelaceValueOf 123 -- not satisfied by any UTxO in 'dsTestMockChain'
-                                        ]
+                                        return
+                                          [ toDelta bOref $ TxSkelRedeemerForScript BRedeemer1
+                                            | (bOref, bOut) <- bUtxos,
+                                              outputValue bOut == Pl.lovelaceValueOf 123 -- not satisfied by any UTxO in 'dsTestMockChain'
+                                          ]
                                     | aValue == Pl.lovelaceValueOf 3_000_000 ->
-                                      return
-                                        [ toDelta bOref $ TxSkelRedeemerForScript BRedeemer1
-                                          | (bOref, bOut) <- bUtxos,
-                                            outputValue bOut == Pl.lovelaceValueOf 6_000_000 -- satisfied by exactly one UTxO in 'dsTestMockChain'
-                                        ]
+                                        return
+                                          [ toDelta bOref $ TxSkelRedeemerForScript BRedeemer1
+                                            | (bOref, bOut) <- bUtxos,
+                                              outputValue bOut == Pl.lovelaceValueOf 6_000_000 -- satisfied by exactly one UTxO in 'dsTestMockChain'
+                                          ]
                                     | aValue == Pl.lovelaceValueOf 4_000_000 ->
-                                      return $
-                                        concatMap
-                                          ( \(bOref, bOut) ->
-                                              let bValue = outputValue bOut
-                                               in if
-                                                      | bValue == Pl.lovelaceValueOf 6_000_000 ->
-                                                        [toDelta bOref $ TxSkelRedeemerForScript BRedeemer1]
-                                                      | bValue == Pl.lovelaceValueOf 7_000_000 ->
-                                                        [ toDelta bOref $ TxSkelRedeemerForScript BRedeemer1,
-                                                          toDelta bOref $ TxSkelRedeemerForScript BRedeemer2
-                                                        ]
-                                                      | otherwise -> []
-                                          )
-                                          bUtxos
+                                        return $
+                                          concatMap
+                                            ( \(bOref, bOut) ->
+                                                let bValue = outputValue bOut
+                                                 in if
+                                                        | bValue == Pl.lovelaceValueOf 6_000_000 ->
+                                                            [toDelta bOref $ TxSkelRedeemerForScript BRedeemer1]
+                                                        | bValue == Pl.lovelaceValueOf 7_000_000 ->
+                                                            [ toDelta bOref $ TxSkelRedeemerForScript BRedeemer1,
+                                                              toDelta bOref $ TxSkelRedeemerForScript BRedeemer2
+                                                            ]
+                                                        | otherwise -> []
+                                            )
+                                            bUtxos
                                     | otherwise -> return []
                             )
                             (wallet 6)

--- a/tests/Cooked/MinAdaSpec.hs
+++ b/tests/Cooked/MinAdaSpec.hs
@@ -53,13 +53,13 @@ tests =
   testGroup
     "automatic minAda adjustment of transaction outputs"
     [ testCase "adjusted transaction passes" $ testSucceeds def paymentWithMinAda,
-      testCase "adjusted transaction contains minimal amount" $
-        testFails
+      testCase "adjusted transaction contains minimal amount"
+        $ testFails
           def
           ( \case
               MCEValidationError (Pl.Phase1, _) -> testSuccess
               MCECalcFee (MCEValidationError (Pl.Phase1, _)) -> testSuccess
               _ -> testFailure
           )
-          $ paymentWithMinAda >>= paymentWithoutMinAda . (+ (-1))
+        $ paymentWithMinAda >>= paymentWithoutMinAda . (+ (-1))
     ]


### PR DESCRIPTION
This pull request ensures that the tools used by our pre-commit hooks and the CI are the exact same than the ones available in the `nix develop .#default` environment. This reduces the size of our derivations by factoring in some things (our SSDs should be happy) and this removes some discrepancies between environments, therefore closing #335.

Because of the aforementioned discrepancies, this pull request also re-formats all the files. The changes are minor but non negligible.