### PR TITLE
Add `PrettyCooked` instances for additional common types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   parameters for balancing and validation of a transaction
 - A function `combineModsTweak` to construct branching tweaks depending on the
   different combinations of foci of an optic on `TxSkel`
+- New `PrettyCooked` instances for common Plutus types
 
 ### Removed
 


### PR DESCRIPTION
This adds some new `PrettyCooked` instances for common types. These were necessary in our latest audit. The list of instances is still not exhaustive. More should be added as we need them.