### PR TITLE
Add tweaks for signers to the non-lens tweak API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - A function `combineModsTweak` to construct branching tweaks depending on the
   different combinations of foci of an optic on `TxSkel`
 - New `PrettyCooked` instances for common Plutus types
+- Tweaks on signers in the non-lens tweak API
 
 ### Removed
 

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -43,6 +43,7 @@ library
       Cooked.Tweak.Common
       Cooked.Tweak.Labels
       Cooked.Tweak.OutPermutations
+      Cooked.Tweak.Signers
       Cooked.Tweak.TamperDatum
       Cooked.Tweak.ValidityRange
       Cooked.ValueUtils

--- a/src/Cooked/Tweak.hs
+++ b/src/Cooked/Tweak.hs
@@ -9,4 +9,5 @@ import Cooked.Tweak.Common as X hiding
   )
 import Cooked.Tweak.Labels as X
 import Cooked.Tweak.OutPermutations as X hiding (distinctPermutations)
+import Cooked.Tweak.Signers as X
 import Cooked.Tweak.TamperDatum as X

--- a/src/Cooked/Tweak/Signers.hs
+++ b/src/Cooked/Tweak/Signers.hs
@@ -66,15 +66,15 @@ addSignersTweak = modifySignersTweak . (<>)
 addLastSignerTweak :: MonadTweak m => Wallet -> m [Wallet]
 addLastSignerTweak = addSignersTweak . (: [])
 
--- | Remove signers from the transaction and returns the old list of signers
+-- | Remove signers from the transaction and return the old list of signers
 removeSignersTweak :: MonadTweak m => [Wallet] -> m [Wallet]
 removeSignersTweak = modifySignersTweak . (\\)
 
--- | Remove a signer from the transaction and returns the old list of signers
+-- | Remove a signer from the transaction and return the old list of signers
 removeSignerTweak :: MonadTweak m => Wallet -> m [Wallet]
 removeSignerTweak = modifySignersTweak . delete
 
--- | Changes the first signer (adds it if there are no signers) and returns the
+-- | Changes the first signer (adds it if there are no signers) and return the
 -- old list of signers.
 replaceFirstSignerTweak :: MonadTweak m => Wallet -> m [Wallet]
 replaceFirstSignerTweak =

--- a/src/Cooked/Tweak/Signers.hs
+++ b/src/Cooked/Tweak/Signers.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE LambdaCase #-}
+
+-- | This module defines 'Tweaks' revolving around the signers of a
+-- transaction. They assume but do not ensure that the list of signers is free
+-- of duplicates.
+module Cooked.Tweak.Signers
+  ( getSignersTweak,
+    modifySignersTweak,
+    setSignersTweak,
+    signersSatisfyTweak,
+    isSignerTweak,
+    hasSignersTweak,
+    addFirstSignerTweak,
+    addSignersTweak,
+    addLastSignerTweak,
+    removeSignersTweak,
+    removeSignerTweak,
+    replaceFirstSignerTweak,
+  )
+where
+
+import Cooked.Skeleton (txSkelSignersL)
+import Cooked.Tweak.Common (MonadTweak, setTweak, viewTweak)
+import Cooked.Wallet (Wallet)
+import Data.List (delete, (\\))
+
+-- | Returns the current list of signers
+getSignersTweak :: MonadTweak m => m [Wallet]
+getSignersTweak = viewTweak txSkelSignersL
+
+-- | Apply a function to the list of signers and return the old ones
+modifySignersTweak :: MonadTweak m => ([Wallet] -> [Wallet]) -> m [Wallet]
+modifySignersTweak f = do
+  oldSigners <- getSignersTweak
+  setTweak txSkelSignersL (f oldSigners)
+  return oldSigners
+
+-- | Change the current signers and return the old ones
+setSignersTweak :: MonadTweak m => [Wallet] -> m [Wallet]
+setSignersTweak = modifySignersTweak . const
+
+-- | Check if the signers satisfy a certain predicate
+signersSatisfyTweak :: MonadTweak m => ([Wallet] -> Bool) -> m Bool
+signersSatisfyTweak = (<$> getSignersTweak)
+
+-- | Check if a wallet signs a transaction
+isSignerTweak :: MonadTweak m => Wallet -> m Bool
+isSignerTweak = signersSatisfyTweak . elem
+
+-- | Check if the transaction has at least a signer
+hasSignersTweak :: MonadTweak m => m Bool
+hasSignersTweak = signersSatisfyTweak (not . null)
+
+-- | Add a signer to the transaction, at the head of the list of signers, and
+-- return the old list of signers
+addFirstSignerTweak :: MonadTweak m => Wallet -> m [Wallet]
+addFirstSignerTweak = modifySignersTweak . (:)
+
+-- | Add signers at the end of the list of signers, and return the old list of
+-- signers
+addSignersTweak :: MonadTweak m => [Wallet] -> m [Wallet]
+addSignersTweak = modifySignersTweak . (<>)
+
+-- | Add a signer to the transaction, at the end of the list of signers, and
+-- return the old list of signers
+addLastSignerTweak :: MonadTweak m => Wallet -> m [Wallet]
+addLastSignerTweak = addSignersTweak . (: [])
+
+-- | Remove signers from the transaction and returns the old list of signers
+removeSignersTweak :: MonadTweak m => [Wallet] -> m [Wallet]
+removeSignersTweak = modifySignersTweak . (\\)
+
+-- | Remove a signer from the transaction and returns the old list of signers
+removeSignerTweak :: MonadTweak m => Wallet -> m [Wallet]
+removeSignerTweak = modifySignersTweak . delete
+
+-- | Changes the first signer (adds it if there are no signers) and returns the
+-- old list of signers.
+replaceFirstSignerTweak :: MonadTweak m => Wallet -> m [Wallet]
+replaceFirstSignerTweak =
+  modifySignersTweak
+    . ( \newSigner -> \case
+          [] -> [newSigner]
+          (_ : ss) -> newSigner : ss
+      )


### PR DESCRIPTION
This adds a `Cooked.Tweak.Signers` module with the following tweaks:

- get signers
- modify signers
- set signers
- check predicate on signers
- check if a wallet is a signer
- check if there are signers
- add a first signer
- append new signers at the end
- append a new signer at the end
- remove signers
- remove one signer
- replace the first signer

These tweaks assume the list of signers has no duplicates but they do not ensure it.
