### PR TITLE
Add lenses for `TxOpts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
   `MonadBlockChainBalancing`.
 - An `UtxoSearch` that starts from a list of `TxOutRef`s
 - A transaction option to choose which UTxOs can be spent for balancing
+- Lenses for the fields of `TxOpts`
 
 ### Removed
 

--- a/src/Cooked/MockChain/Balancing.hs
+++ b/src/Cooked/MockChain/Balancing.hs
@@ -245,8 +245,8 @@ setFeeAndBalance balanceWallet skel0 = do
            in case txOptBalancingUtxos . txSkelOpts $ skel0 of
                 BalancingUtxosAll -> utxosAtLedger balanceWalletAddress
                 BalancingUtxosDatumless -> runUtxoSearch (utxosAtLedgerSearch balanceWalletAddress `filterWithPred` noDatumPredicate)
-                BalancingUtxosWith txOutRefs -> filter ((`elem` txOutRefs) . fst) <$> utxosAtLedger balanceWalletAddress
-                BalancingUtxosWithout txOutRefs -> filter (not . (`elem` txOutRefs) . fst) <$> utxosAtLedger balanceWalletAddress
+                BalancingUtxosAllowlist txOutRefs -> filter ((`elem` txOutRefs) . fst) <$> utxosAtLedger balanceWalletAddress
+                BalancingUtxosBlocklist txOutRefs -> filter (not . (`elem` txOutRefs) . fst) <$> utxosAtLedger balanceWalletAddress
 
   -- all UTxOs that the txSkel consumes.
   txSkelUtxos <- txSkelInputUtxos skel

--- a/src/Cooked/Pretty/Cooked.hs
+++ b/src/Cooked/Pretty/Cooked.hs
@@ -404,9 +404,9 @@ mPrettyTxOpts
       prettyBalancingUtxos :: BalancingUtxos -> DocCooked
       prettyBalancingUtxos BalancingUtxosAll = "Balance with all UTxOs of the balancing wallet"
       prettyBalancingUtxos BalancingUtxosDatumless = "Balance with datumless UTxOs of the balancing wallet"
-      prettyBalancingUtxos (BalancingUtxosWith txOutRefs) =
+      prettyBalancingUtxos (BalancingUtxosAllowlist txOutRefs) =
         prettyItemize "Only balance with UTxOs of the balancing wallet among:" "-" (prettyCookedOpt opts <$> txOutRefs)
-      prettyBalancingUtxos (BalancingUtxosWithout txOutRefs) =
+      prettyBalancingUtxos (BalancingUtxosBlocklist txOutRefs) =
         prettyItemize "Do not balance with UTxOs among:" "-" (prettyCookedOpt opts <$> txOutRefs)
 
 -- * Pretty-printing

--- a/src/Cooked/Skeleton.hs
+++ b/src/Cooked/Skeleton.hs
@@ -31,6 +31,7 @@ module Cooked.Skeleton
     txOptBalanceL,
     txOptBalanceOutputPolicyL,
     txOptBalanceWalletL,
+    txOptBalancingUtxosL,
     txOptEmulatorParamsModificationL,
     MintsConstrs,
     MintsRedeemer (..),
@@ -304,6 +305,7 @@ makeLensesFor
     ("txOptBalance", "txOptBalanceL"),
     ("txOptBalanceOutputPolicy", "txOptBalanceOutputPolicyL"),
     ("txOptBalanceWallet", "txOptBalanceWalletL"),
+    ("txOptBalancingUtxos", "txOptBalancingUtxosL"),
     ("txOptEmulatorParamsModification", "txOptEmulatorParamsModificationL")
   ]
   ''TxOpts

--- a/src/Cooked/Skeleton.hs
+++ b/src/Cooked/Skeleton.hs
@@ -24,6 +24,14 @@ module Cooked.Skeleton
     applyEmulatorParamsModification,
     applyRawModOnBalancedTx,
     TxOpts (..),
+    txOptEnsureMinAdaL,
+    txOptAwaitTxConfirmedL,
+    txOptAutoSlotIncreaseL,
+    txOptUnsafeModTxL,
+    txOptBalanceL,
+    txOptBalanceOutputPolicyL,
+    txOptBalanceWalletL,
+    txOptEmulatorParamsModificationL,
     MintsConstrs,
     MintsRedeemer (..),
     TxSkelMints,
@@ -287,6 +295,18 @@ data TxOpts = TxOpts
     txOptEmulatorParamsModification :: Maybe EmulatorParamsModification
   }
   deriving (Eq, Show)
+
+makeLensesFor
+  [ ("txOptEnsureMinAda", "txOptEnsureMinAdaL"),
+    ("txOptAwaitTxConfirmed", "txOptAwaitTxConfirmedL"),
+    ("txOptAutoSlotIncrease", "txOptAutoSlotIncreaseL"),
+    ("txOptUnsafeModTx", "txOptUnsafeModTxL"),
+    ("txOptBalance", "txOptBalanceL"),
+    ("txOptBalanceOutputPolicy", "txOptBalanceOutputPolicyL"),
+    ("txOptBalanceWallet", "txOptBalanceWalletL"),
+    ("txOptEmulatorParamsModification", "txOptEmulatorParamsModificationL")
+  ]
+  ''TxOpts
 
 instance Default TxOpts where
   def =

--- a/src/Cooked/Skeleton.hs
+++ b/src/Cooked/Skeleton.hs
@@ -211,9 +211,9 @@ data BalancingUtxos
   | -- | Use all UTxOs without datum
     BalancingUtxosDatumless
   | -- | Use only the provided UTxOs
-    BalancingUtxosWith [Pl2.TxOutRef]
+    BalancingUtxosAllowlist [Pl2.TxOutRef]
   | -- | Do not use the provided UTxOs
-    BalancingUtxosWithout [Pl2.TxOutRef]
+    BalancingUtxosBlocklist [Pl2.TxOutRef]
   deriving (Eq, Ord, Show)
 
 instance Default BalancingUtxos where


### PR DESCRIPTION
This adds lenses for transaction skeletons options. This is useful in tweaks since the options are not exposed in the tweaks API.