### PR TITLE
Small fixes after first audit with cooked V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
   different combinations of foci of an optic on `TxSkel`
 - New `PrettyCooked` instances for common Plutus types
 - Tweaks on signers in the non-lens tweak API
+- A function `resolveTypedDatum` to recover typed data on UTxOs in
+  `MonadBlockChainBalancing`.
+- An `UtxoSearch` that starts from a list of `TxOutRef`s
 
 ### Removed
 
@@ -46,6 +49,12 @@
   2. Rename `Cooked.testFailsFrom'` into `Cooked.testFailsFrom`.
   3. (Bonus) simplify, knowing that ``Cooked.testFailsFrom o x def ==
      Cooked.testFails o x``
+
+### Fixes
+
+- Add forgotten export of `permanentValue`
+- In `MockChainT`: don't delete data on transaction inputs if there are still
+  UTxOs with that datum around. (See PR #354)
 
 ## [[2.0.0]](https://github.com/tweag/cooked-validators/releases/tag/v2.0.0) - 2023-02-28
 

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 

--- a/src/Cooked/Currencies.hs
+++ b/src/Cooked/Currencies.hs
@@ -33,6 +33,7 @@ module Cooked.Currencies
     quickValue,
     permanentTokenName,
     permanentAssetClass,
+    permanentValue,
     quickCurrencyPolicy,
     quickCurrencySymbol,
     permanentCurrencyPolicy,

--- a/src/Cooked/MockChain/BlockChain.hs
+++ b/src/Cooked/MockChain/BlockChain.hs
@@ -224,7 +224,7 @@ resolveTypedDatum out = do
           <$> Just (out' ^. outputOwnerL)
           <*> Just (out' ^. outputStakingCredentialL)
           <*> Just (out' ^. outputValueL)
-          <*> (case out' ^. outputDatumL of PV2.Datum datum -> PV2.fromBuiltinData datum)
+          <*> (let PV2.Datum datum = out' ^. outputDatumL in PV2.fromBuiltinData datum)
           <*> Just (out' ^. outputReferenceScriptL)
 
 -- | Try to resolve the validator that owns an output: If the output is owned by

--- a/src/Cooked/MockChain/BlockChain.hs
+++ b/src/Cooked/MockChain/BlockChain.hs
@@ -31,6 +31,7 @@ module Cooked.MockChain.BlockChain
     outputDatumFromTxOutRef,
     datumFromTxOutRef,
     resolveDatum,
+    resolveTypedDatum,
     resolveValidator,
     resolveReferenceScript,
     getEnclosingSlot,
@@ -203,7 +204,30 @@ resolveDatum out =
           (out ^. outputReferenceScriptL)
     PV2.NoOutputDatum -> return Nothing
 
--- | Try to resolve the validator that owns an output: If the output is owned by
+-- | Like 'resolveDatum', but also tries to use 'fromBuiltinData' to extract a
+-- datum of the suitable type.
+resolveTypedDatum ::
+  ( IsAbstractOutput out,
+    ToOutputDatum (DatumType out),
+    MonadBlockChainBalancing m,
+    PV2.FromData a
+  ) =>
+  out ->
+  m (Maybe (ConcreteOutput (OwnerType out) a (ValueType out) (ReferenceScriptType out)))
+resolveTypedDatum out = do
+  mOut <- resolveDatum out
+  case mOut of
+    Nothing -> return Nothing
+    Just out' ->
+      return $
+        ConcreteOutput
+          <$> Just (out' ^. outputOwnerL)
+          <*> Just (out' ^. outputStakingCredentialL)
+          <*> Just (out' ^. outputValueL)
+          <*> (case out' ^. outputDatumL of PV2.Datum datum -> PV2.fromBuiltinData datum)
+          <*> Just (out' ^. outputReferenceScriptL)
+
+-- | try to resolve the validator that owns an output: If the output is owned by
 -- a public key, or if the validator's hash is not known (i.e. if
 -- 'validatorFromHash' returns @Nothing@) return @Nothing@.
 resolveValidator ::

--- a/src/Cooked/MockChain/BlockChain.hs
+++ b/src/Cooked/MockChain/BlockChain.hs
@@ -227,7 +227,7 @@ resolveTypedDatum out = do
           <*> (case out' ^. outputDatumL of PV2.Datum datum -> PV2.fromBuiltinData datum)
           <*> Just (out' ^. outputReferenceScriptL)
 
--- | try to resolve the validator that owns an output: If the output is owned by
+-- | Try to resolve the validator that owns an output: If the output is owned by
 -- a public key, or if the validator's hash is not known (i.e. if
 -- 'validatorFromHash' returns @Nothing@) return @Nothing@.
 resolveValidator ::

--- a/src/Cooked/MockChain/Direct.hs
+++ b/src/Cooked/MockChain/Direct.hs
@@ -379,14 +379,13 @@ runTransactionValidation theParams cardanoTx rawModTx consumedData producedData 
     Right _ -> do
       -- Validation succeeded; now we update the UTxO index, the managed
       -- datums, and the managed Validators. The new mcstIndex is just
-      -- `newUtxoIndex`; the new mcstDatums is computed by removing the datum
-      -- hashes have been consumed and adding those that have been created in
-      -- the transaction.
+      -- `newUtxoIndex`; the new mcstDatums is computed by adding those that
+      -- have been created in the transaction.
       modify'
         ( \st ->
             st
               { mcstIndex = newUtxoIndex,
-                mcstDatums = (mcstDatums st Map.\\ consumedData) `Map.union` producedData,
+                mcstDatums = mcstDatums st `Map.union` producedData, -- TODO how to remove consumed data? We can't just remove them; the datum might still be sitting at another UTxO
                 mcstValidators = mcstValidators st `Map.union` outputValidators
               }
         )

--- a/src/Cooked/MockChain/Direct.hs
+++ b/src/Cooked/MockChain/Direct.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StrictData #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
@@ -74,19 +75,22 @@ mcstToUtxoState MockChainSt {mcstIndex, mcstDatums} =
         txSkelOutDatum <-
           case txOutDatum of
             Pl.NoOutputDatum -> Just TxSkelOutNoDatum
-            Pl.OutputDatum datum -> Map.lookup (Pl.datumHash datum) mcstDatums
-            Pl.OutputDatumHash hash -> Map.lookup hash mcstDatums
+            Pl.OutputDatum datum -> fst <$> Map.lookup (Pl.datumHash datum) mcstDatums
+            Pl.OutputDatumHash hash -> fst <$> Map.lookup hash mcstDatums
         return
           ( txOutAddress,
             UtxoPayloadSet [UtxoPayload txOutRef txOutValue txSkelOutDatum mRefScript]
           )
 
 -- | Slightly more concrete version of 'UtxoState', used to actually run the
--- simulation. We keep a map from datum hash to datum in order to display the
--- contents of the state to the user.
+-- simulation.
 data MockChainSt = MockChainSt
   { mcstIndex :: Ledger.UtxoIndex,
-    mcstDatums :: Map Pl.DatumHash TxSkelOutDatum,
+    -- map from datum hash to (datum, count), where count is the number of
+    -- UTxOs that currently have the datum. This map is used  to display the
+    -- contents of the state to the user, and to recover datums for transaction
+    -- generation.
+    mcstDatums :: Map Pl.DatumHash (TxSkelOutDatum, Integer),
     mcstValidators :: Map Pl.ValidatorHash (Pl.Versioned Pl.Validator),
     mcstCurrentSlot :: Ledger.Slot
   }
@@ -305,7 +309,7 @@ instance Monad m => MonadBlockChainBalancing (MockChainT m) where
   getParams = asks mceParams
   validatorFromHash valHash = gets $ Map.lookup valHash . mcstValidators
   txOutByRefLedger outref = gets $ Map.lookup outref . getIndex . mcstIndex
-  datumFromHash datumHash = (txSkelOutUntypedDatum <=< Map.lookup datumHash) <$> gets mcstDatums
+  datumFromHash datumHash = (txSkelOutUntypedDatum <=< Just . fst <=< Map.lookup datumHash) <$> gets mcstDatums
   utxosAtLedger addr = filter ((addr ==) . outputAddress . txOutV2FromLedger . snd) <$> allUtxosLedger
 
 instance Monad m => MonadBlockChainWithoutValidation (MockChainT m) where
@@ -380,13 +384,17 @@ runTransactionValidation theParams cardanoTx rawModTx consumedData producedData 
       -- Validation succeeded; now we update the UTxO index, the managed
       -- datums, and the managed Validators. The new mcstIndex is just
       -- `newUtxoIndex`; the new mcstDatums is computed by adding those that
-      -- have been created in the transaction.
+      -- have been created in the transaction and removing those that were
+      -- consumed (or reducing their count in the 'mcstDatums').
       modify'
         ( \st ->
             st
               { mcstIndex = newUtxoIndex,
-                mcstDatums = mcstDatums st `Map.union` producedData, -- TODO how to remove consumed data? We can't just remove them; the datum might still be sitting at another UTxO
+                mcstDatums = (mcstDatums st `removeMcstDatums` consumedData) `addMcstDatums` producedData,
                 mcstValidators = mcstValidators st `Map.union` outputValidators
               }
         )
       return (Ledger.CardanoEmulatorEraTx cardanoTx)
+  where
+    addMcstDatums stored new = Map.unionWith (\(d, n1) (_, n2) -> (d, n1 + n2)) stored (Map.map (,1) new)
+    removeMcstDatums = Map.differenceWith $ \(d, n) _ -> if n == 0 then Nothing else Just (d, n - 1)

--- a/src/Cooked/MockChain/Staged.hs
+++ b/src/Cooked/MockChain/Staged.hs
@@ -37,6 +37,7 @@ import Cooked.MockChain.UtxoState
 import Cooked.Skeleton
 import Cooked.Tweak.Common
 import Data.Default
+import qualified Data.Map as Map
 import qualified Ledger.Slot as Ledger
 import qualified Ledger.Tx as Ledger
 import qualified Ledger.Tx.CardanoAPI as Ledger
@@ -153,7 +154,7 @@ instance InterpLtl (UntypedTweak InterpMockChain) MockChainBuiltin InterpMockCha
             tell $
               MockChainLog
                 [ MCLogSubmittedTxSkel
-                    (SkelContext (txOutV2FromLedger <$> managedTxOuts) managedDatums)
+                    (SkelContext (txOutV2FromLedger <$> managedTxOuts) $ Map.map fst managedDatums)
                     skel'
                 ]
         tx <- validateTxSkel skel'

--- a/src/Cooked/MockChain/UtxoSearch.hs
+++ b/src/Cooked/MockChain/UtxoSearch.hs
@@ -9,7 +9,7 @@ module Cooked.MockChain.UtxoSearch
     utxosAtSearch,
     utxosAtLedgerSearch,
     utxosFromCardanoTxSearch,
-    utxosFromTxOutRefsSearch,
+    txOutByRefSearch,
     filterWith,
     filterWithPure,
     filterWithOptic,

--- a/src/Cooked/MockChain/UtxoSearch.hs
+++ b/src/Cooked/MockChain/UtxoSearch.hs
@@ -9,6 +9,7 @@ module Cooked.MockChain.UtxoSearch
     utxosAtSearch,
     utxosAtLedgerSearch,
     utxosFromCardanoTxSearch,
+    utxosFromTxOutRefsSearch,
     filterWith,
     filterWithPure,
     filterWithOptic,
@@ -58,6 +59,14 @@ utxosAtLedgerSearch = utxosAtLedger >=> ListT.fromFoldable
 -- 'TxInfo'-'TxOut'.
 utxosFromCardanoTxSearch :: Monad m => Ledger.CardanoTx -> UtxoSearch m Pl2.TxOut
 utxosFromCardanoTxSearch = ListT.fromFoldable . utxosFromCardanoTx
+
+-- | Search all 'TxInfo'-'TxOut's corresponding to given the list of
+-- 'TxOutRef's. Any 'TxOutRef' that doesn't correspond to a known output will be
+-- filtered out.
+txOutByRefSearch :: MonadBlockChainBalancing m => [Pl2.TxOutRef] -> UtxoSearch m Pl2.TxOut
+txOutByRefSearch orefs =
+  ListT.traverse (\o -> return (o, o)) (ListT.fromFoldable orefs)
+    `filterWith` txOutByRef
 
 -- * filtering UTxO searches
 


### PR DESCRIPTION
This PR incorporates a few changes we made to cooked during our first audit using V2. These are:

## Export `permanentValue` from the `Cooked.Currencies` module

For some reason, we had forgotten it in the export list.

## Add an `UtxoSearch` that takes a list of `TxOutRef`s

We now have 

```haskell
txOutByRefSearch :: MonadBlockChainBalancing m => [TxOutRef] -> UtxoSearch m TxOut
```

This function will try to resolve the `TxOut` at each of the given `TxOutRefs`, and returns an `UtxoSearch` of all those `TxOut`s that could be resolved.

## Add a function to resolve typed datums

The function

```haskell
resolveTypedDatum :: (IsAbstractOutput out, ..., FromBuiltinData a, MonadBlockChainBalancing m) => 
  out ->
  m (Maybe (ConcreteOutput (OwnerType our) a (ValueType out) (ReferenceScriptType out))
```

tries to resolve a datum of a specific type on any output type with an `IsAbstractOutput` instance. This can be used as a filter in `UtxoSearch`es, for example.

## Fix a bug in how we keep track of data in `MockChainT`

On successful submission of transactions, we were deleting the data on the transaction inputs from the `mcstDatums`. This meant that, if exactly the same datum sat around on another UTxO somewhere, `MockChainT` would not be able to resolve it, and consequently run into errors at the next time the datum was requested. (This happens at the latest while creating the transaction that tries to cosume the UTxO.)

The solution I choose is the simplest: Just never delete anything from the `mcstDatums`. This is obviously suboptimal, since it means that `mcstDatums`always grows during a trace. I don't think that's too bad, though, since it is a map (this means constant access time), and we're probably never never going to use so many datums that the size becomes a problem. The only cheap alternative I see at the moment would be scanning the whole `mcstIndex` every time we want to delete a datum, and that seems even less appealing.