### PR TITLE
Add a balancing UTxOs skeleton option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - A function `resolveTypedDatum` to recover typed data on UTxOs in
   `MonadBlockChainBalancing`.
 - An `UtxoSearch` that starts from a list of `TxOutRef`s
+- A transaction option to choose which UTxOs can be spent for balancing
 
 ### Removed
 

--- a/src/Cooked/MockChain/Balancing.hs
+++ b/src/Cooked/MockChain/Balancing.hs
@@ -242,7 +242,7 @@ setFeeAndBalance balanceWallet skel0 = do
     Map.fromList
       <$> let balanceWalletAddress = walletAddress balanceWallet
               noDatumPredicate = (\case PV2.NoOutputDatum -> True; _ -> False) . outputOutputDatum . txOutV2FromLedger
-           in case txOptBalancingUTxOs . txSkelOpts $ skel0 of
+           in case txOptBalancingUtxos . txSkelOpts $ skel0 of
                 BalancingUtxosAll -> utxosAtLedger balanceWalletAddress
                 BalancingUtxosDatumless -> runUtxoSearch (utxosAtLedgerSearch balanceWalletAddress `filterWithPred` noDatumPredicate)
                 BalancingUtxosWith txOutRefs -> filter ((`elem` txOutRefs) . fst) <$> utxosAtLedger balanceWalletAddress

--- a/src/Cooked/MockChain/Balancing.hs
+++ b/src/Cooked/MockChain/Balancing.hs
@@ -236,8 +236,18 @@ setFeeAndBalance balanceWallet skel0 = do
     if txOptEnsureMinAda . txSkelOpts $ skel0
       then ensureTxSkelOutsMinAda skel0
       else return skel0
-  -- all UTxOs belonging to the balancing public key
-  balancePKUtxos <- Map.fromList <$> utxosAtLedger (walletAddress balanceWallet)
+
+  -- Candidate UTxOs to spend for balancing
+  balancePKUtxos <-
+    Map.fromList
+      <$> let balanceWalletAddress = walletAddress balanceWallet
+              noDatumPredicate = (\case PV2.NoOutputDatum -> True; _ -> False) . outputOutputDatum . txOutV2FromLedger
+           in case txOptBalancingUTxOs . txSkelOpts $ skel0 of
+                BalancingUtxosAll -> utxosAtLedger balanceWalletAddress
+                BalancingUtxosDatumless -> runUtxoSearch (utxosAtLedgerSearch balanceWalletAddress `filterWithPred` noDatumPredicate)
+                BalancingUtxosWith txOutRefs -> filter ((`elem` txOutRefs) . fst) <$> utxosAtLedger balanceWalletAddress
+                BalancingUtxosWithout txOutRefs -> filter (not . (`elem` txOutRefs) . fst) <$> utxosAtLedger balanceWalletAddress
+
   -- all UTxOs that the txSkel consumes.
   txSkelUtxos <- txSkelInputUtxos skel
   -- all UTxOs that the txSkel references.

--- a/src/Cooked/Pretty/Cooked.hs
+++ b/src/Cooked/Pretty/Cooked.hs
@@ -357,7 +357,8 @@ mPrettyTxOpts
       txOptBalance,
       txOptBalanceOutputPolicy,
       txOptBalanceWallet,
-      txOptEmulatorParamsModification
+      txOptEmulatorParamsModification,
+      txOptBalancingUTxOs
     } =
     prettyItemizeNonEmpty "Options:" "-" $
       catMaybes
@@ -367,7 +368,8 @@ mPrettyTxOpts
           prettyIfNot def prettyBalanceOutputPolicy txOptBalanceOutputPolicy,
           prettyIfNot def prettyBalanceWallet txOptBalanceWallet,
           prettyIfNot [] prettyUnsafeModTx txOptUnsafeModTx,
-          prettyIfNot def prettyEmulatorParamsModification txOptEmulatorParamsModification
+          prettyIfNot def prettyEmulatorParamsModification txOptEmulatorParamsModification,
+          prettyIfNot def prettyBalancingUtxos txOptBalancingUTxOs
         ]
     where
       prettyIfNot :: Eq a => a -> (a -> DocCooked) -> a -> Maybe DocCooked
@@ -399,6 +401,13 @@ mPrettyTxOpts
       prettyEmulatorParamsModification :: Maybe EmulatorParamsModification -> DocCooked
       prettyEmulatorParamsModification Nothing = "No modifications of protocol paramters"
       prettyEmulatorParamsModification Just {} = "With modifications of protocol parameters"
+      prettyBalancingUtxos :: BalancingUtxos -> DocCooked
+      prettyBalancingUtxos BalancingUtxosAll = "Balance with all UTxOs of the balancing wallet"
+      prettyBalancingUtxos BalancingUtxosDatumless = "Balance with datumless UTxOs of the balancing wallet"
+      prettyBalancingUtxos (BalancingUtxosWith txOutRefs) =
+        prettyItemize "Only balance with UTxOs of the balancing wallet among:" "-" (prettyCookedOpt opts <$> txOutRefs)
+      prettyBalancingUtxos (BalancingUtxosWithout txOutRefs) =
+        prettyItemize "Do not balance with UTxOs among:" "-" (prettyCookedOpt opts <$> txOutRefs)
 
 -- * Pretty-printing
 

--- a/src/Cooked/Pretty/Cooked.hs
+++ b/src/Cooked/Pretty/Cooked.hs
@@ -357,8 +357,8 @@ mPrettyTxOpts
       txOptBalance,
       txOptBalanceOutputPolicy,
       txOptBalanceWallet,
-      txOptEmulatorParamsModification,
-      txOptBalancingUTxOs
+      txOptBalancingUtxos,
+      txOptEmulatorParamsModification
     } =
     prettyItemizeNonEmpty "Options:" "-" $
       catMaybes
@@ -367,9 +367,9 @@ mPrettyTxOpts
           prettyIfNot True prettyBalance txOptBalance,
           prettyIfNot def prettyBalanceOutputPolicy txOptBalanceOutputPolicy,
           prettyIfNot def prettyBalanceWallet txOptBalanceWallet,
+          prettyIfNot def prettyBalancingUtxos txOptBalancingUtxos,
           prettyIfNot [] prettyUnsafeModTx txOptUnsafeModTx,
-          prettyIfNot def prettyEmulatorParamsModification txOptEmulatorParamsModification,
-          prettyIfNot def prettyBalancingUtxos txOptBalancingUTxOs
+          prettyIfNot def prettyEmulatorParamsModification txOptEmulatorParamsModification
         ]
     where
       prettyIfNot :: Eq a => a -> (a -> DocCooked) -> a -> Maybe DocCooked

--- a/src/Cooked/Skeleton.hs
+++ b/src/Cooked/Skeleton.hs
@@ -76,7 +76,6 @@ where
 import qualified Cardano.Api as C
 import qualified Cardano.Node.Emulator as Emulator
 import Control.Monad
-import Control.Monad.List (ListT)
 import Cooked.Output
 import Cooked.Pretty.Class
 import Cooked.ValueUtils
@@ -212,19 +211,81 @@ instance Default BalancingUtxos where
   def = BalancingUtxosAll
 
 -- | Set of options to modify the behavior of generating and validating some transaction.
-data TxOpts where
-  TxOpts ::
-    { txOptEnsureMinAda :: Bool,
-      txOptAwaitTxConfirmed :: Bool,
-      txOptAutoSlotIncrease :: Bool,
-      txOptUnsafeModTx :: [RawModTx],
-      txOptBalance :: Bool,
-      txOptBalanceOutputPolicy :: BalanceOutputPolicy,
-      txOptBalanceWallet :: BalancingWallet,
-      txOptEmulatorParamsModification :: Maybe EmulatorParamsModification,
-      txOptBalancingUTxOs :: BalancingUtxos
-    } ->
-    TxOpts
+data TxOpts = TxOpts
+  { -- | Performs an adjustment to unbalanced transactions, making sure every
+    -- UTxO that is produced has the necessary minimum amount of Ada.
+    --
+    -- Default is @False@.
+    txOptEnsureMinAda :: Bool,
+    -- | Ignore this for now. Deprecated.
+    txOptAwaitTxConfirmed :: Bool,
+    -- | Whether to increase the slot counter automatically on transaction
+    -- submission.  This is useful for modelling transactions that could be
+    -- submitted in parallel in reality, so there should be no explicit ordering
+    -- of what comes first.
+    --
+    -- Default is @True@.
+    txOptAutoSlotIncrease :: Bool,
+    -- | Applies an arbitrary modification to a transaction after it has been
+    -- potentially adjusted ('txOptEnsureMinAda') and balanced. The name of this
+    -- option contains /unsafe/ to draw attention to the fact that modifying a
+    -- transaction at that stage might make it invalid. Still, this offers a
+    -- hook for being able to alter a transaction in unforeseen ways. It is
+    -- mostly used to test contracts that have been written for custom PABs.
+    --
+    -- One interesting use of this function is to observe a transaction just
+    -- before it is being sent for validation, with
+    --
+    -- > txOptUnsafeModTx = [RawModTxAfterBalancing Debug.Trace.traceShowId]
+    --
+    -- The leftmost function in the list is applied first.
+    --
+    -- Default is @[]@.
+    txOptUnsafeModTx :: [RawModTx],
+    -- | Whether to balance the transaction or not. Balancing ensures that
+    --
+    -- > input + mints == output + fees + burns
+    --
+    -- If you decide to set @txOptBalance = False@ you will have trouble
+    -- satisfying that equation by hand because @fees@ are variable. You will
+    -- likely see a error about value preservation, and should adjust the fees
+    -- accordingly.
+    --
+    -- Default is @True@, and nobody in their right mind will ever set it
+    -- otherwise.
+    txOptBalance :: Bool,
+    -- | The 'BalanceOutputPolicy' to apply when balancing the transaction.
+    --
+    -- Default is 'AdjustExistingOutput'.
+    txOptBalanceOutputPolicy :: BalanceOutputPolicy,
+    -- | Which wallet to use to provide outputs for balancing and collaterals.
+    -- Either the first signer by default, or an explicit wallet. In the second
+    -- case, this wallet must be a signer of the transaction. This option WILL
+    -- NOT ensure that it is added in case it is not already present in the list
+    -- of signers.
+    --
+    -- Default is 'BalanceWithFirstSigner'.
+    txOptBalanceWallet :: BalancingWallet,
+    -- | Describes which UTxOs of the balancing wallet can be spent for
+    -- balancing. This is useful to put aside some UTxOs you want to spend in a
+    -- specific context later and prevent premature spending during balancing
+    -- of previous transactions.
+    txOptBalancingUtxos :: BalancingUtxos,
+    -- | Apply an arbitrary modification to the protocol parameters that are
+    -- used to balance and submit the transaction. This is
+    -- obviously a very unsafe thing to do if you want to preserve
+    -- compatibility with the actual chain. It is useful mainly for testing
+    -- purposes, when you might want to use extremely big transactions or
+    -- transactions that exhaust the maximum execution budget. Such a thing
+    -- could be accomplished with
+    --
+    -- > txOptEmulatorParamsModification = Just $ EmulatorParamsModification increaseTransactionLimits
+    --
+    -- for example.
+    --
+    -- Default is 'Nothing'.
+    txOptEmulatorParamsModification :: Maybe EmulatorParamsModification
+  }
   deriving (Eq, Show)
 
 instance Default TxOpts where
@@ -237,8 +298,8 @@ instance Default TxOpts where
         txOptBalance = True,
         txOptBalanceOutputPolicy = def,
         txOptBalanceWallet = def,
-        txOptEmulatorParamsModification = Nothing,
-        txOptBalancingUTxOs = def
+        txOptBalancingUtxos = def,
+        txOptEmulatorParamsModification = Nothing
       }
 
 -- * Description of the Minting


### PR DESCRIPTION
### Problem

Sometimes, there are pubkey UTxOs that we don't want to spend until we need them as inputs or reference inputs later.
Currently, balancing does not care which UTxOs of the balancing wallet it spends.
Example situation: information stored on a pubkey UTxO made official with an NFT

### Remediation

A new option in `TxOpts` to control which UTxOs are safe to spend for balancing.

### The ideal and conceptually elegant solution

Use a `UtxoSearch` as the option.

### Why it is inconvenient

* Module dependency cycle involving `UtxoSearch`, `Skeleton`, and `BlockChain`. This seems solvable, we only need the definition of the `UtxoSearch` synonym in `Skeleton`.
* `TxOpts` is data, it has `Eq` and `Show` instances that it would not be able to implement anymore. A `UtxoSearch` is indeed at heart a function.

Tackling these would have a significant impact on the existing codebase for a small convenience feature.

### The pragmatic proposed solution

* A `BalancingUtxos` option which can be set to:
    * Use all UTxOs like before
    * Allow to use UTxOs in a whitelist of `TxOutRef`
    * Forbid to use UTxOs in a blacklist of `TxOutRef`
    * Use UTxOs without datum
* Integrates well in the existing codebase
    * No module reorganization
    * `TxOpts` remains `Eq` and `Show`-able as usual
* It is still possible to use filters (`UtxoSearch`) right before the transaction and provide the obtained list of `TxOutRef` as a whitelist or blacklist
* Almost all the time, in practice, the `BalancingUtxosDatumless` will be what we want. UTxOs we want to protect against premature spending are UTxOs that carry info in a datum.