### PR TITLE
Remove unused dependencies

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,24 +11,17 @@ source-repository-package
   subdir:
     cardano-node-emulator
     cardano-streaming
-    doc
     freer-extras
     marconi-chain-index
     marconi-core
-    marconi-sidechain
     pab-blockfrost
     plutus-chain-index
     plutus-chain-index-core
     plutus-contract
-    plutus-contract-certification
-    plutus-e2e-tests
-    plutus-example
     plutus-ledger
     plutus-pab
-    plutus-pab-executables
     plutus-script-utils
     plutus-tx-constraints
-    plutus-use-cases
 
 -- Everything below this point has been copied from plutus-apps' cabal.project
 

--- a/cabal.project
+++ b/cabal.project
@@ -11,7 +11,6 @@ source-repository-package
   subdir:
     cardano-node-emulator
     cardano-streaming
-    freer-extras
     marconi-chain-index
     marconi-core
     pab-blockfrost

--- a/cabal.project
+++ b/cabal.project
@@ -19,7 +19,6 @@ source-repository-package
     plutus-chain-index-core
     plutus-contract
     plutus-ledger
-    plutus-pab
     plutus-script-utils
     plutus-tx-constraints
 

--- a/cabal.project
+++ b/cabal.project
@@ -11,6 +11,7 @@ source-repository-package
   subdir:
     cardano-node-emulator
     cardano-streaming
+    freer-extras
     marconi-chain-index
     marconi-core
     pab-blockfrost

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -86,6 +86,7 @@ library
     , plutus-core
     , plutus-ledger
     , plutus-ledger-api
+    , plutus-script-utils
     , plutus-tx
     , plutus-tx-plugin
     , prettyprinter
@@ -160,6 +161,7 @@ test-suite spec
     , plutus-core
     , plutus-ledger
     , plutus-ledger-api
+    , plutus-script-utils
     , plutus-tx
     , plutus-tx-plugin
     , prettyprinter

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -84,6 +84,7 @@ library
     , optics-vl
     , plutus-contract
     , plutus-core
+    , plutus-ledger
     , plutus-ledger-api
     , plutus-pab
     , plutus-script-utils
@@ -159,6 +160,7 @@ test-suite spec
     , parsec
     , plutus-contract
     , plutus-core
+    , plutus-ledger
     , plutus-ledger-api
     , plutus-pab
     , plutus-script-utils

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -82,6 +82,7 @@ library
     , optics-core
     , optics-th
     , optics-vl
+    , plutus-contract
     , plutus-core
     , plutus-ledger
     , plutus-ledger-api
@@ -157,6 +158,7 @@ test-suite spec
     , optics-th
     , optics-vl
     , parsec
+    , plutus-contract
     , plutus-core
     , plutus-ledger
     , plutus-ledger-api

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -84,7 +84,6 @@ library
     , optics-vl
     , plutus-contract
     , plutus-core
-    , plutus-ledger
     , plutus-ledger-api
     , plutus-pab
     , plutus-script-utils
@@ -160,7 +159,6 @@ test-suite spec
     , parsec
     , plutus-contract
     , plutus-core
-    , plutus-ledger
     , plutus-ledger-api
     , plutus-pab
     , plutus-script-utils

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -86,7 +86,6 @@ library
     , plutus-core
     , plutus-ledger
     , plutus-ledger-api
-    , plutus-pab
     , plutus-script-utils
     , plutus-tx
     , plutus-tx-plugin
@@ -162,7 +161,6 @@ test-suite spec
     , plutus-core
     , plutus-ledger
     , plutus-ledger-api
-    , plutus-pab
     , plutus-script-utils
     , plutus-tx
     , plutus-tx-plugin

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -71,8 +71,6 @@ library
     , either
     , flat
     , foldl
-    , freer-extras
-    , freer-simple
     , hashable
     , hedgehog-quickcheck
     , lens
@@ -148,8 +146,6 @@ test-suite spec
     , either
     , flat
     , foldl
-    , freer-extras
-    , freer-simple
     , hashable
     , hedgehog-quickcheck
     , lens

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -86,7 +86,6 @@ library
     , plutus-core
     , plutus-ledger
     , plutus-ledger-api
-    , plutus-script-utils
     , plutus-tx
     , plutus-tx-plugin
     , prettyprinter
@@ -161,7 +160,6 @@ test-suite spec
     , plutus-core
     , plutus-ledger
     , plutus-ledger-api
-    , plutus-script-utils
     , plutus-tx
     , plutus-tx-plugin
     , prettyprinter

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -82,7 +82,6 @@ library
     , optics-core
     , optics-th
     , optics-vl
-    , plutus-contract
     , plutus-core
     , plutus-ledger
     , plutus-ledger-api
@@ -158,7 +157,6 @@ test-suite spec
     , optics-th
     , optics-vl
     , parsec
-    , plutus-contract
     , plutus-core
     , plutus-ledger
     , plutus-ledger-api

--- a/package.yaml
+++ b/package.yaml
@@ -35,7 +35,6 @@ dependencies:
   - plutus-core
   - plutus-ledger
   - plutus-ledger-api
-  - plutus-script-utils
   - plutus-tx
   - plutus-tx-plugin
   - prettyprinter

--- a/package.yaml
+++ b/package.yaml
@@ -33,7 +33,6 @@ dependencies:
   - optics-vl
   - plutus-contract
   - plutus-core
-  - plutus-ledger
   - plutus-ledger-api
   - plutus-pab
   - plutus-script-utils

--- a/package.yaml
+++ b/package.yaml
@@ -20,8 +20,6 @@ dependencies:
   - either
   - flat
   - foldl
-  - freer-extras
-  - freer-simple
   - hashable
   - hedgehog-quickcheck
   - lens

--- a/package.yaml
+++ b/package.yaml
@@ -35,6 +35,7 @@ dependencies:
   - plutus-core
   - plutus-ledger
   - plutus-ledger-api
+  - plutus-script-utils
   - plutus-tx
   - plutus-tx-plugin
   - prettyprinter

--- a/package.yaml
+++ b/package.yaml
@@ -35,7 +35,6 @@ dependencies:
   - plutus-core
   - plutus-ledger
   - plutus-ledger-api
-  - plutus-pab
   - plutus-script-utils
   - plutus-tx
   - plutus-tx-plugin

--- a/package.yaml
+++ b/package.yaml
@@ -33,6 +33,7 @@ dependencies:
   - optics-vl
   - plutus-contract
   - plutus-core
+  - plutus-ledger
   - plutus-ledger-api
   - plutus-pab
   - plutus-script-utils

--- a/package.yaml
+++ b/package.yaml
@@ -31,7 +31,6 @@ dependencies:
   - optics-core
   - optics-th
   - optics-vl
-  - plutus-contract
   - plutus-core
   - plutus-ledger
   - plutus-ledger-api

--- a/package.yaml
+++ b/package.yaml
@@ -31,6 +31,7 @@ dependencies:
   - optics-core
   - optics-th
   - optics-vl
+  - plutus-contract
   - plutus-core
   - plutus-ledger
   - plutus-ledger-api


### PR DESCRIPTION
_This PR is meant to be squashed._

This PR aims at cleaning up our dependencies, and in particular our dependencies in `plutus-apps`. I will slowly remove things from the `package.yaml` file and check that everything still compiles fine. I will keep all the process in the Git history of this PR in case someone wants to have a better look at the CI errors and such. I will also edit this description to explain why I kept some packages.

My work is guided by [this Google spreadsheet](https://docs.google.com/spreadsheets/d/107D5Vn7M2Uyrw-yLb2dzVHv-1PvFm_ratVN15GW5DfI).

In `package.yaml`, I could only remove `freer-simple`, `freer-extras` and `plutus-pab`. The rest is used:

- `cardano-node-emulator`: I am not even trying, we are heavily depending on it.

- `plutus-contract`: we are apparently depending on it:
  ```
  Building library for cooked-validators-2.0.0..
  [13 of 37] Compiling Cooked.MockChain.GenerateTx ( src/Cooked/MockChain/GenerateTx.hs, [...] ) [Wallet.API changed]
  
  src/Cooked/MockChain/GenerateTx.hs:40:1: error:
      Could not load module ‘Wallet.API’
      It is a member of the hidden package ‘plutus-contract-1.2.0.0’.
     |
  40 | import qualified Wallet.API as Pl
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ```

- `plutus-ledger`: we are apparently depending on it:
  ```
  Building library for cooked-validators-2.0.0..
  [ 1 of 37] Compiling Cooked.Currencies ( src/Cooked/Currencies.hs, [...] ) [Ledger.Typed.Scripts changed]

  src/Cooked/Currencies.hs:44:1: error:
      Could not load module ‘Ledger.Typed.Scripts’
      It is a member of the hidden package ‘plutus-ledger-1.2.0.0’.
     |
  44 | import qualified Ledger.Typed.Scripts as Scripts
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ```

- `plutus-scripts-utils`: we are apparently depending on it:
  ```
  Building library for cooked-validators-2.0.0..
  [ 1 of 37] Compiling Cooked.Currencies ( src/Cooked/Currencies.hs, [...] ) [Plutus.Script.Utils.V1.Scripts changed]

  src/Cooked/Currencies.hs:45:1: error:
      Could not load module ‘Plutus.Script.Utils.V1.Scripts’
      It is a member of the hidden package ‘plutus-script-utils-1.2.0.0’.
     |
  45 | import qualified Plutus.Script.Utils.V1.Scripts as Validation
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ```

In `cabal.project`, I could remove `doc`, `marconi-sidechain`, `plutus-contract-certification`, `plutus-e2e-tests`, `plutus-example`, `plutus-pab-executables` and `plutus-use-cases`, all already known to be unused. Additionally, I could now remove `plutus-pab`. `freer-extras` is necessary as a dependency of `cardano-node-emulator`.