### PR TITLE
Printing unresolved txins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - Add forgotten export of `permanentValue`
 - In `MockChainT`: don't delete data on transaction inputs if there are still
   UTxOs with that datum around. (See PR #354)
+- Prettyprint unresolved transaction inputs
 
 ## [[2.0.0]](https://github.com/tweag/cooked-validators/releases/tag/v2.0.0) - 2023-02-28
 


### PR DESCRIPTION
TxIns were not handled by the prettyprinter when they happened to be not resolved. This fixes it.