### PR TITLE
Ltl `there` modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [Cheatsheet](doc/CHEATSHEET.md)
 - API now exposes: `Cooked.Tweak.ValidityRange`, `interpretAndRun`, 
   `interpretAndRunWith`, `runTweak`, `runTweakFrom` and `datumHijackingTarget`
+- `there` modifier to apply a tweak at a precise place in a trace
 
 ### Removed
 


### PR DESCRIPTION
Adds the `there` modifier to precisely modify an endpoint within a trace.