### PR TITLE
Tests with coverage

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,10 @@
 packages:
   .
 
+package cooked-validators
+  coverage: True
+  library-coverage: True
+  
 package cardano-crypto-praos
   flags: -external-libsodium-vrf
 
@@ -23,7 +27,6 @@ source-repository-package
     plutus-tx-constraints
 
 -- Everything below this point has been copied from plutus-apps' cabal.project
-
 
 -- Custom repository for cardano haskell packages
 -- See https://github.com/input-output-hk/cardano-haskell-packages on how to use CHaP in a Haskell project.

--- a/flake.nix
+++ b/flake.nix
@@ -69,9 +69,13 @@
             ## one pinned by HLS.
             buildInputs = buildInputs ++ (with pkgs; [ ormolu hpack hlint ])
               ++ (with hpkgs; [ haskell-language-server ]);
-            inherit (pre-commit) shellHook;
+
             inherit LD_LIBRARY_PATH;
             inherit LANG;
+
+            shellHook = pre-commit.shellHook + ''
+              alias cabal-test='cabal --test-option=--color=always test all | grep -vE --color=never "^Writing:.*html$"'
+            '';
           };
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,7 @@
             inherit LANG;
 
             shellHook = pre-commit.shellHook + ''
+              export PATH=$PATH:./scripts
               alias cabal-test='cabal --test-option=--color=always test all | grep -vE --color=never "^Writing:.*html$"'
             '';
           };

--- a/flake.nix
+++ b/flake.nix
@@ -73,9 +73,18 @@
             inherit LD_LIBRARY_PATH;
             inherit LANG;
 
+            # In addition to the pre-commit hooks, this redefines a cabal
+            # command that gets rid of annoying "Writing: .....*.html" output
+            # when running cabal test.
             shellHook = pre-commit.shellHook + ''
-              export PATH=$PATH:./scripts
-              alias cabal-test='cabal --test-option=--color=always test all | grep -vE --color=never "^Writing:.*html$"'
+              function cabal() {
+                    if [ "$1" != "test" ]; then
+                      command cabal $@
+                    else
+                      command cabal --test-option=--color=always $@ | grep -vE --color=never "^Writing:.*html$"
+                    fi
+              }
+              export -f cabal
             '';
           };
         };

--- a/scripts/cabal
+++ b/scripts/cabal
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-
-
-cabal --test-option=--color=always test all | grep -vE --color=never "^Writing:.*html$"

--- a/scripts/cabal
+++ b/scripts/cabal
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+
+
+cabal --test-option=--color=always test all | grep -vE --color=never "^Writing:.*html$"


### PR DESCRIPTION
This enables the coverage feature when running the test suite: it generates HTML files that recap graphically how much of each module is covered. It also adds annoying junk lines on the output. Therefore, we define a `cabal` wrapper in the flake to filter out these lines when testing.

This solves #283 