### PR TITLE
New initial distributions with datums and reference scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@
 - New pretty-printing options related to hashes in `pcOptHashes` including the
   possibility to assign human readable names to hashes (pubkeys, scripts,
   minting policies)
+- Initial distributions of funds can now include arbitrat payments
+  instead of only consisting of values belonging to wallets. In
+  particular, we can now initially pay to scripts and have utxos with
+  datums and reference scripts. We can still create an initial
+  distribution in the old fashion way with `distributionFromList` or
+  directly provide a list of payments with `InitialDistribution`.
+- Dummy pre-existing validators in `Cooked.Validators` to be used for
+  testing purposes mainly but also as targets for attacks and tweaks.
+- Small QOL helpers (`ada`, `lovelace` and `adaAssetClass`) to create
+  values in `Cooked.ValueUtils`.
 
 ### Removed
 
@@ -63,6 +73,7 @@
   3. (Bonus) simplify, knowing that ``Cooked.testFailsFrom o x def ==
      Cooked.testFails o x``
 - Quick and permanent value minting policies have been migrated to PlutusV2.
+- Default initial distribution only provides 5 UTxOs per wallet instead of 10.
 
 ### Fixes
 

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -19,6 +19,7 @@ library
       Cooked.Attack.DoubleSat
       Cooked.Attack.DupToken
       Cooked.Currencies
+      Cooked.Distribution
       Cooked.Ltl
       Cooked.MockChain
       Cooked.MockChain.Balancing

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -19,7 +19,7 @@ library
       Cooked.Attack.DoubleSat
       Cooked.Attack.DupToken
       Cooked.Currencies
-      Cooked.Distribution
+      Cooked.InitialDistribution
       Cooked.Ltl
       Cooked.MockChain
       Cooked.MockChain.Balancing

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -48,6 +48,7 @@ library
       Cooked.Tweak.Signers
       Cooked.Tweak.TamperDatum
       Cooked.Tweak.ValidityRange
+      Cooked.Validators
       Cooked.ValueUtils
       Cooked.Wallet
   other-modules:
@@ -111,6 +112,7 @@ test-suite spec
       Cooked.Attack.DoubleSatSpec
       Cooked.Attack.DupTokenSpec
       Cooked.AttackSpec
+      Cooked.InitialDistributionSpec
       Cooked.InlineDatumsSpec
       Cooked.LtlSpec
       Cooked.MinAdaSpec

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -16,12 +16,32 @@
     * `printCooked $ interpretAndRun foo` for all traces
     * `printCooked $ runMockChain foo` for `MonadBlockChain` traces only
 
-### Use a custom initial distribution of value
+### Custom initial distributions of UTxOs
 
-```haskell
-initDist :: InitialDistribution
-initDist = initialDistribution [(i, [lovelaceValueOf 25_000_000]) | i <- knownWallets]
-```
+#### Creation
+
+* With only values
+  ```haskell
+  initDist :: InitialDistribution
+  initDist = distributionFromList $
+	  [ (wallet 1 , [ ada 42 , ada 2 <> quickValue "TOK" 1 ]
+	  , (wallet 2 , [ ada 10 ])
+	  , (wallet 3 , [ ada 10 <> permanentValue "XYZ" 10])
+	  ]
+  ```
+* With arbitrary payments
+  ```haskell
+  initDist :: InitialDistribution
+  initDist = InitialDistribution
+	  [ paysPK (walletPKHash (wallet 3)) (ada 6)
+      , paysScript fooTypedValidator FooTypedDatum (lovelaceValueOf 6_000_000)
+	  , paysPK (walletPKHash (wallet 2)) (ada 2) `withDatum` fooDatum
+	  , paysPK (walletPKHash (wallet 1)) (ada 2) `withReferenceScript` fooValidator
+	  ]
+  ```
+
+#### Usage
+
 * In a test `Tasty.testCase "foo" $ testSucceedsFrom def initDist foo`
 * In the REPL `printCooked $ interpretAndRunWith (runMockChainTFrom initDist) foo`
 

--- a/src/Cooked.hs
+++ b/src/Cooked.hs
@@ -9,7 +9,7 @@ where
 
 import Cooked.Attack as X
 import Cooked.Currencies as X
-import Cooked.Distribution as X
+import Cooked.InitialDistribution as X
 import qualified Cooked.Ltl as Ltl
 import Cooked.MockChain as X
 import Cooked.Output as X

--- a/src/Cooked.hs
+++ b/src/Cooked.hs
@@ -9,6 +9,7 @@ where
 
 import Cooked.Attack as X
 import Cooked.Currencies as X
+import Cooked.Distribution as X
 import qualified Cooked.Ltl as Ltl
 import Cooked.MockChain as X
 import Cooked.Output as X

--- a/src/Cooked.hs
+++ b/src/Cooked.hs
@@ -18,5 +18,6 @@ import Cooked.RawUPLC as X
 import Cooked.ShowBS as X
 import Cooked.Skeleton as X
 import Cooked.Tweak as X
+import Cooked.Validators as X
 import Cooked.ValueUtils as X
 import Cooked.Wallet as X

--- a/src/Cooked/Distribution.hs
+++ b/src/Cooked/Distribution.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+module Cooked.Distribution
+  ( initialDistribution,
+    InitialDistribution (..),
+  )
+where
+
+import Cooked.Wallet
+import Data.Default
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Plutus.Script.Utils.Ada as Pl
+import qualified Plutus.Script.Utils.Value as Pl
+
+-- * Initial distribution of funds
+
+-- | Describes the initial distribution of UTxOs per wallet. This is important
+-- since transaction validation must specify a /collateral/. Hence, wallets
+-- must have more than one UTxO to begin with in order to execute a transaction
+-- and have some collateral option. The @txCollateral@ is transferred to the
+-- node operator in case the transaction fails to validate.
+--
+--  The following specifies a starting state where @wallet 1@ contains two
+--  UTxOs, one with 42 Ada and one with 2 Ada and one "TOK" token; @wallet 2@
+--  contains a single UTxO with 10 Ada and @wallet 3@ has 10 Ada and a
+--  permanent value. See "Cooked.Currencies" for more information on quick and
+--  permanent values.
+--
+--  > i0 = InitialDistribution $ M.fromList
+--  >        [ (wallet 1 , [ Pl.lovelaveValueOf 42_000_000
+--  >                      , Pl.lovelaceValueOf 2_000_000 <> quickValue "TOK" 1
+--  >                      ]
+--  >        , (wallet 2 , [Pl.lovelaveValueOf 10_000_000])
+--  >        , (wallet 3 , [Pl.lovelaceValueOf 10_000_000 <> permanentValue "XYZ" 10])
+--  >        ]
+newtype InitialDistribution = InitialDistribution
+  { unInitialDistribution :: Map Wallet [Pl.Value]
+  }
+  deriving (Eq, Show)
+
+instance Semigroup InitialDistribution where
+  (InitialDistribution i) <> (InitialDistribution j) =
+    InitialDistribution $ Map.unionWith (<>) i j
+
+instance Monoid InitialDistribution where
+  mempty = InitialDistribution Map.empty
+
+-- | 10 UTxOs with 100 Ada each, for each of the 'knownWallets'.
+instance Default InitialDistribution where
+  def =
+    InitialDistribution $
+      Map.fromList $
+        zip knownWallets (repeat $ replicate 10 defLovelace)
+    where
+      defLovelace = Pl.lovelaceValueOf 100_000_000
+
+distributionFromList :: [(Wallet, [Pl.Value])] -> InitialDistribution
+distributionFromList = InitialDistribution . Map.fromList
+
+initialDistribution :: [(Wallet, [Pl.Value])] -> InitialDistribution
+initialDistribution = (def <>) . distributionFromList

--- a/src/Cooked/InitialDistribution.hs
+++ b/src/Cooked/InitialDistribution.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE NumericUnderscores #-}
 
-module Cooked.Distribution
+module Cooked.InitialDistribution
   ( initialDistribution,
     InitialDistribution (..),
   )

--- a/src/Cooked/InitialDistribution.hs
+++ b/src/Cooked/InitialDistribution.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE NumericUnderscores #-}
-
 -- | This module provides a convenient way to spread assets between
 -- wallets and scripts at the initialization of the mock chain. These
 -- initial assets can be accompanied by datums and reference scripts.
@@ -24,7 +22,6 @@ import Data.Bifunctor (second)
 import Data.Default
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import qualified Plutus.Script.Utils.Ada as Pl
 import qualified Plutus.Script.Utils.V2.Typed.Scripts.Validators as Pl
 import qualified Plutus.Script.Utils.Value as Pl
 import qualified Plutus.V2.Ledger.Api as Pl
@@ -38,22 +35,20 @@ import qualified Plutus.V2.Ledger.Api as Pl
 -- option. The @txCollateral@ is transferred to the node operator in
 -- case the transaction fails to validate.
 --
---  The following specifies a starting state where @wallet 1@ contains
---  two UTxOs, one with 42 Ada and one with 2 Ada and one "TOK" token;
---  @wallet 2@ contains a single UTxO with 10 Ada and @wallet 3@ has
---  10 Ada and a permanent value. See "Cooked.Currencies" for more
+--  The following specifies a starting state where @wallet 1@ owns two
+--  UTxOs, one with 42 Ada and one with 2 Ada and one "TOK" token;
+--  @wallet 2@ owns a single UTxO with 10 Ada and @wallet 3@ has 10
+--  Ada and a permanent value. See "Cooked.Currencies" for more
 --  information on quick and permanent values.
 --
 --  > i0 = InitialDistribution $ M.fromList
---  >        [ (wallet 1 , [ Pl.lovelaveValueOf 42_000_000
---  >                      , Pl.lovelaceValueOf 2_000_000 <> quickValue "TOK" 1
---  >                      ]
---  >        , (wallet 2 , [Pl.lovelaveValueOf 10_000_000])
---  >        , (wallet 3 , [Pl.lovelaceValueOf 10_000_000 <> permanentValue "XYZ" 10])
+--  >        [ (wallet 1 , [ ada 42 , ada 2 <> quickValue "TOK" 1 ]
+--  >        , (wallet 2 , [ ada 10 ])
+--  >        , (wallet 3 , [ ada 10 <> permanentValue "XYZ" 10])
 --  >        ]
 
 -- | This represents what can be placed within UTxOs in the initial
--- distribution: a value, a datum and a possible reference
+-- distribution: a value, a datum andq a possible reference
 data UTxOContent = UTxOContent
   { ucValue :: Pl.Value,
     ucDatum :: Pl.OutputDatum,
@@ -79,7 +74,8 @@ withReferenceScript content script = content {ucScript = Just $ toScriptHash scr
 referenceScriptToUTxOContent :: Pl.TypedValidator a -> UTxOContent
 referenceScriptToUTxOContent = withReferenceScript def
 
--- | An initial distribution associates a list of UTxOContent to wallets
+-- | An initial distribution associates a list of UTxOContent to
+-- wallets
 newtype InitialDistribution = InitialDistribution
   { unInitialDistribution :: Map Wallet [UTxOContent]
   }
@@ -92,7 +88,8 @@ instance Semigroup InitialDistribution where
 instance Monoid InitialDistribution where
   mempty = InitialDistribution Map.empty
 
--- | 5 UTxOs with 100 Ada each, for each of the 'knownWallets', without any datum nor scripts
+-- | 5 UTxOs with 100 Ada each, for each of the 'knownWallets',
+-- without any datum nor scripts
 instance Default InitialDistribution where
   def =
     distributionFromList
@@ -100,8 +97,7 @@ instance Default InitialDistribution where
       . repeat
       . replicate 5
       . valueToUTxOContent
-      . Pl.lovelaceValueOf
-      $ 100_000_000
+      $ ada 100
 
 distributionFromList :: [(Wallet, [UTxOContent])] -> InitialDistribution
 distributionFromList = InitialDistribution . Map.fromList

--- a/src/Cooked/InitialDistribution.hs
+++ b/src/Cooked/InitialDistribution.hs
@@ -56,13 +56,8 @@ data UTxOContent = UTxOContent
   }
   deriving (Eq, Show)
 
-class ToUTxOContent a where
-  toUTxOContent :: a -> UTxOContent
-
 valueToUTxOContent :: Pl.Value -> UTxOContent
 valueToUTxOContent val = UTxOContent val Pl.NoOutputDatum Nothing
-
--- TODO: value, datums and script are convertible to utxo content
 
 instance Default UTxOContent where
   def = valueToUTxOContent (ada 2)

--- a/src/Cooked/InitialDistribution.hs
+++ b/src/Cooked/InitialDistribution.hs
@@ -31,7 +31,7 @@ import qualified Plutus.Script.Utils.Value as Pl
 --  Ada and a permanent value. See "Cooked.Currencies" for more
 --  information on quick and permanent values.
 --
---  > i0 = InitialDistributionFromList $
+--  > i0 = distributionFromList $
 --  >        [ (wallet 1 , [ ada 42 , ada 2 <> quickValue "TOK" 1 ]
 --  >        , (wallet 2 , [ ada 10 ])
 --  >        , (wallet 3 , [ ada 10 <> permanentValue "XYZ" 10])

--- a/src/Cooked/InitialDistribution.hs
+++ b/src/Cooked/InitialDistribution.hs
@@ -41,7 +41,7 @@ import qualified Plutus.V2.Ledger.Api as Pl
 --  Ada and a permanent value. See "Cooked.Currencies" for more
 --  information on quick and permanent values.
 --
---  > i0 = InitialDistribution $ M.fromList
+--  > i0 = InitialDistributionFromValueList $
 --  >        [ (wallet 1 , [ ada 42 , ada 2 <> quickValue "TOK" 1 ]
 --  >        , (wallet 2 , [ ada 10 ])
 --  >        , (wallet 3 , [ ada 10 <> permanentValue "XYZ" 10])
@@ -56,8 +56,13 @@ data UTxOContent = UTxOContent
   }
   deriving (Eq, Show)
 
+class ToUTxOContent a where
+  toUTxOContent :: a -> UTxOContent
+
 valueToUTxOContent :: Pl.Value -> UTxOContent
 valueToUTxOContent val = UTxOContent val Pl.NoOutputDatum Nothing
+
+-- TODO: value, datums and script are convertible to utxo content
 
 instance Default UTxOContent where
   def = valueToUTxOContent (ada 2)

--- a/src/Cooked/InitialDistribution.hs
+++ b/src/Cooked/InitialDistribution.hs
@@ -6,8 +6,8 @@ module Cooked.InitialDistribution
     InitialDistribution (..),
     valueToUTxOContent,
     UTxOContent (..),
-    withDatum,
-    withReferenceScript,
+    addDatum,
+    addReferenceScript,
     datumToUTxOContent,
     referenceScriptToUTxOContent,
     distributionFromList,
@@ -62,17 +62,17 @@ valueToUTxOContent val = UTxOContent val Pl.NoOutputDatum Nothing
 instance Default UTxOContent where
   def = valueToUTxOContent (ada 2)
 
-withDatum :: (Pl.ToData a) => UTxOContent -> a -> UTxOContent
-withDatum content datum = content {ucDatum = toOutputDatum $ Pl.toBuiltinData datum}
+addDatum :: (Pl.ToData a) => UTxOContent -> a -> UTxOContent
+addDatum content datum = content {ucDatum = toOutputDatum $ Pl.toBuiltinData datum}
 
 datumToUTxOContent :: (Pl.ToData a) => a -> UTxOContent
-datumToUTxOContent = withDatum def
+datumToUTxOContent = addDatum def
 
-withReferenceScript :: UTxOContent -> Pl.TypedValidator a -> UTxOContent
-withReferenceScript content script = content {ucScript = Just $ toScriptHash script}
+addReferenceScript :: UTxOContent -> Pl.TypedValidator a -> UTxOContent
+addReferenceScript content script = content {ucScript = Just $ toScriptHash script}
 
 referenceScriptToUTxOContent :: Pl.TypedValidator a -> UTxOContent
-referenceScriptToUTxOContent = withReferenceScript def
+referenceScriptToUTxOContent = addReferenceScript def
 
 -- | An initial distribution associates a list of UTxOContent to
 -- wallets

--- a/src/Cooked/InitialDistribution.hs
+++ b/src/Cooked/InitialDistribution.hs
@@ -1,30 +1,20 @@
+{-# LANGUAGE GADTs #-}
+
 -- | This module provides a convenient way to spread assets between
 -- wallets and scripts at the initialization of the mock chain. These
 -- initial assets can be accompanied by datums and reference scripts.
 module Cooked.InitialDistribution
-  ( initialDistribution,
-    InitialDistribution (..),
-    valueToUTxOContent,
-    UTxOContent (..),
-    addDatum,
-    addReferenceScript,
-    datumToUTxOContent,
-    referenceScriptToUTxOContent,
+  ( InitialDistribution (..),
     distributionFromList,
-    distributionFromValueList,
   )
 where
 
-import Cooked.Output
+import Cooked.Skeleton
 import Cooked.ValueUtils
 import Cooked.Wallet
-import Data.Bifunctor (second)
 import Data.Default
-import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
-import qualified Plutus.Script.Utils.V2.Typed.Scripts.Validators as Pl
+import Data.List
 import qualified Plutus.Script.Utils.Value as Pl
-import qualified Plutus.V2.Ledger.Api as Pl
 
 -- * Initial distribution of funds
 
@@ -41,52 +31,13 @@ import qualified Plutus.V2.Ledger.Api as Pl
 --  Ada and a permanent value. See "Cooked.Currencies" for more
 --  information on quick and permanent values.
 --
---  > i0 = InitialDistributionFromValueList $
+--  > i0 = InitialDistributionFromList $
 --  >        [ (wallet 1 , [ ada 42 , ada 2 <> quickValue "TOK" 1 ]
 --  >        , (wallet 2 , [ ada 10 ])
 --  >        , (wallet 3 , [ ada 10 <> permanentValue "XYZ" 10])
 --  >        ]
-
--- | This represents what can be placed within UTxOs in the initial
--- distribution: a value, a datum andq a possible reference
-data UTxOContent = UTxOContent
-  { ucValue :: Pl.Value,
-    ucDatum :: Pl.OutputDatum,
-    ucScript :: Maybe Pl.ScriptHash
-  }
-  deriving (Eq, Show)
-
-valueToUTxOContent :: Pl.Value -> UTxOContent
-valueToUTxOContent val = UTxOContent val Pl.NoOutputDatum Nothing
-
-instance Default UTxOContent where
-  def = valueToUTxOContent (ada 2)
-
-addDatum :: (Pl.ToData a) => UTxOContent -> a -> UTxOContent
-addDatum content datum = content {ucDatum = toOutputDatum $ Pl.toBuiltinData datum}
-
-datumToUTxOContent :: (Pl.ToData a) => a -> UTxOContent
-datumToUTxOContent = addDatum def
-
-addReferenceScript :: UTxOContent -> Pl.TypedValidator a -> UTxOContent
-addReferenceScript content script = content {ucScript = Just $ toScriptHash script}
-
-referenceScriptToUTxOContent :: Pl.TypedValidator a -> UTxOContent
-referenceScriptToUTxOContent = addReferenceScript def
-
--- | An initial distribution associates a list of UTxOContent to
--- wallets
-newtype InitialDistribution = InitialDistribution
-  { unInitialDistribution :: Map Wallet [UTxOContent]
-  }
-  deriving (Eq, Show)
-
-instance Semigroup InitialDistribution where
-  (InitialDistribution i) <> (InitialDistribution j) =
-    InitialDistribution $ Map.unionWith (<>) i j
-
-instance Monoid InitialDistribution where
-  mempty = InitialDistribution Map.empty
+data InitialDistribution where
+  InitialDistribution :: {initialDistribution :: [TxSkelOut]} -> InitialDistribution
 
 -- | 5 UTxOs with 100 Ada each, for each of the 'knownWallets',
 -- without any datum nor scripts
@@ -96,14 +47,7 @@ instance Default InitialDistribution where
       . zip knownWallets
       . repeat
       . replicate 5
-      . valueToUTxOContent
       $ ada 100
 
-distributionFromList :: [(Wallet, [UTxOContent])] -> InitialDistribution
-distributionFromList = InitialDistribution . Map.fromList
-
-distributionFromValueList :: [(Wallet, [Pl.Value])] -> InitialDistribution
-distributionFromValueList = distributionFromList . map (second $ map valueToUTxOContent)
-
-initialDistribution :: [(Wallet, [UTxOContent])] -> InitialDistribution
-initialDistribution = (def <>) . distributionFromList
+distributionFromList :: [(Wallet, [Pl.Value])] -> InitialDistribution
+distributionFromList = InitialDistribution . foldl' (\x (user, values) -> x <> map (paysPK (walletPKHash user)) values) []

--- a/src/Cooked/MockChain/Balancing.hs
+++ b/src/Cooked/MockChain/Balancing.hs
@@ -15,6 +15,7 @@ import qualified Cardano.Api as C
 import qualified Cardano.Api.Shelley as C
 import qualified Cardano.Ledger.Shelley.API as CardanoLedger
 import qualified Cardano.Node.Emulator as Emulator
+import qualified Cardano.Node.Emulator.Params as Pl
 import Control.Arrow
 import Control.Monad.Except
 import Cooked.MockChain.BlockChain
@@ -98,7 +99,7 @@ ensureTxSkelOutsMinAda skel = do
   where
     ensureTxSkelOutHasMinAda :: Emulator.Params -> TxSkelOut -> Either GenerateTxError TxSkelOut
     ensureTxSkelOutHasMinAda theParams txSkelOut@(Pays output) = do
-      cardanoTxOut <- txSkelOutToCardanoTxOut theParams txSkelOut
+      cardanoTxOut <- txSkelOutToCardanoTxOut (Pl.pNetworkId theParams) txSkelOut
       let Pl.Lovelace oldAda = output ^. outputValueL % adaL
           CardanoLedger.Coin requiredAda =
             CardanoLedger.evaluateMinLovelaceOutput (Emulator.emulatorPParams theParams)

--- a/src/Cooked/MockChain/Direct.hs
+++ b/src/Cooked/MockChain/Direct.hs
@@ -26,7 +26,7 @@ import Control.Monad.Except
 import Control.Monad.Identity
 import Control.Monad.Reader
 import Control.Monad.State.Strict
-import Cooked.Distribution
+import Cooked.InitialDistribution
 import Cooked.MockChain.Balancing
 import Cooked.MockChain.BlockChain
 import Cooked.MockChain.UtxoState

--- a/src/Cooked/MockChain/Direct.hs
+++ b/src/Cooked/MockChain/Direct.hs
@@ -26,6 +26,7 @@ import Control.Monad.Except
 import Control.Monad.Identity
 import Control.Monad.Reader
 import Control.Monad.State.Strict
+import Cooked.Distribution
 import Cooked.MockChain.Balancing
 import Cooked.MockChain.BlockChain
 import Cooked.MockChain.UtxoState
@@ -281,7 +282,7 @@ utxoIndex0From i0 = Ledger.initialise [[Ledger.Valid $ initialTxFor i0]]
           fromRight' $
             Ledger.toCardanoTxOut
               theNetworkId
-              (PV2.TxOut addr value datum Nothing)
+              (PV2.TxOut addr value datum (Just undefined))
 
         theNetworkId :: C.NetworkId
         theNetworkId = C.Testnet $ C.NetworkMagic 42 -- TODO PORT what's magic?

--- a/src/Cooked/MockChain/Direct.hs
+++ b/src/Cooked/MockChain/Direct.hs
@@ -34,6 +34,7 @@ import Cooked.Output
 import Cooked.Skeleton
 import Data.Bifunctor (bimap)
 import Data.Default
+import Data.Either.Combinators (mapLeft)
 import Data.List (foldl')
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -215,6 +216,8 @@ utxoState0 = mcstToUtxoState mockChainSt0
 mockChainSt0 :: MockChainSt
 mockChainSt0 = MockChainSt utxoIndex0 Map.empty Map.empty def
 
+-- * Initial `MockChainSt` from an initial distribution
+
 mockChainSt0From :: InitialDistribution -> MockChainSt
 mockChainSt0From i0 =
   MockChainSt
@@ -226,9 +229,16 @@ mockChainSt0From i0 =
 instance Default MockChainSt where
   def = mockChainSt0
 
+-- | Reference scripts from initial distributions should be accounted
+-- for in the `MockChainSt` which is done using this function.
 referenceScriptMap0From :: InitialDistribution -> Map Pl.ValidatorHash (Pl.Versioned Pl.Validator)
-referenceScriptMap0From (InitialDistribution initDist) = Map.fromList $ mapMaybe unitMaybeFrom initDist
+referenceScriptMap0From (InitialDistribution initDist) =
+  -- This builds a map of entries from the reference scripts contained
+  -- in the initial distribution
+  Map.fromList $ mapMaybe unitMaybeFrom initDist
   where
+    -- This takes a single output and returns a possible map entry
+    -- when it contains a reference script
     unitMaybeFrom :: TxSkelOut -> Maybe (Pl.ValidatorHash, Pl.Versioned Pl.Validator)
     unitMaybeFrom (Pays output) = do
       refScript <- view outputReferenceScriptL output
@@ -236,55 +246,46 @@ referenceScriptMap0From (InitialDistribution initDist) = Map.fromList $ mapMaybe
           Pl.ScriptHash scriptHash = toScriptHash vScript
       return (Pl.ValidatorHash scriptHash, Pl.Versioned (Pl.Validator script) version)
 
+-- | Datums from initial distributions should be accounted for in the
+-- `MockChainSt` which is done using this function.
 datumMap0From :: InitialDistribution -> Map Pl.DatumHash (TxSkelOutDatum, Integer)
 datumMap0From (InitialDistribution initDist) =
-  foldl'
-    (\m -> Map.unionWith (\(d, n1) (_, n2) -> (d, n1 + n2)) m . unitMapFrom)
-    Map.empty
-    initDist
+  -- This concatenates singleton maps from inputs and accounts for the
+  -- number of occurrences of similar datums
+  foldl' (\m -> Map.unionWith (\(d, n1) (_, n2) -> (d, n1 + n2)) m . unitMapFrom) Map.empty initDist
   where
+    -- This takes a single output and creates an empty map if it
+    -- contains no datum, or a singleton map if it contains one
     unitMapFrom :: TxSkelOut -> Map Pl.DatumHash (TxSkelOutDatum, Integer)
     unitMapFrom txSkelOut =
       let datum = view txSkelOutDatumL txSkelOut
        in maybe Map.empty (flip Map.singleton (datum, 1) . Pl.datumHash) $ txSkelOutUntypedDatum datum
 
+-- | This creates the initial UtxoIndex from an initial distribution
+-- by submitted an initial transaction with the appropriate content:
+--
+-- - inputs consist of a single dummy pseudo input
+--
+-- - all assets in outputs are considered minted
+--
+-- - outputs are translated from the `TxSkelOut` list in the initial
+-- - distribution
 utxoIndex0From :: InitialDistribution -> Ledger.UtxoIndex
-utxoIndex0From i0 = Ledger.initialise [[Ledger.Valid $ initialTxFor i0]]
+utxoIndex0From (InitialDistribution initDist) = case mkBody of
+  Left err -> error $ show err
+  Right body -> Ledger.initialise [[Ledger.Valid $ Ledger.CardanoEmulatorEraTx $ C.Tx body []]]
   where
-    -- Bootstraps an initial transaction resulting in a state where wallets
-    -- possess UTxOs fitting a given 'InitialDistribution'
-    initialTxFor :: InitialDistribution -> Ledger.CardanoTx
-    initialTxFor (InitialDistribution initDist) = Ledger.CardanoEmulatorEraTx $ C.Tx body []
-      where
-        body :: C.TxBody C.BabbageEra
-        body =
-          fromRight' $
-            C.makeTransactionBody $
-              Ledger.emptyTxBodyContent
-                { C.txMintValue =
-                    flip (C.TxMintValue C.MultiAssetInBabbageEra) (C.BuildTxWith mempty)
-                      . C.filterValue (/= C.AdaAssetId)
-                      . fromRight'
-                      . Ledger.toCardanoValue
-                      $ foldl' (\v -> (v <>) . view txSkelOutValueL) mempty initDist,
-                  C.txOuts = fromRight' . txSkelOutToCardanoTxOut theNetworkId <$> initDist,
-                  C.txIns = [(C.genesisUTxOPseudoTxIn theNetworkId genesisKeyHash, C.BuildTxWith $ C.KeyWitness C.KeyWitnessForSpending)]
-                }
-
-        -- This has been taken  from the Test.Cardano.Api.Genesis example transaction here:
-        -- https://github.com/input-output-hk/cardano-node/blob/543b267d75d3d448e1940f9ec04b42bd01bbb16b/cardano-api/test/Test/Cardano/Api/Genesis.hs#L60
-        genesisKeyHash :: C.Hash C.GenesisUTxOKey
-        genesisKeyHash =
-          C.GenesisUTxOKeyHash $
-            CardanoLedger.KeyHash "23d51e91ae5adc7ae801e9de4cd54175fb7464ec2680b25686bbb194"
-
-        fromRight' :: (Show e) => Either e a -> a
-        fromRight' x = case x of
-          Left err -> error $ show err
-          Right res -> res
-
-        theNetworkId :: C.NetworkId
-        theNetworkId = C.Testnet $ C.NetworkMagic 42 -- TODO PORT what's magic?
+    mkBody :: Either GenerateTxError (C.TxBody C.BabbageEra)
+    mkBody = do
+      value <- mapLeft (ToCardanoError "Value error") $ Ledger.toCardanoValue (foldl' (\v -> (v <>) . view txSkelOutValueL) mempty initDist)
+      let mintValue = flip (C.TxMintValue C.MultiAssetInBabbageEra) (C.BuildTxWith mempty) . C.filterValue (/= C.AdaAssetId) $ value
+          theNetworkId = C.Testnet $ C.NetworkMagic 42 -- TODO PORT what's magic?
+          -- This has been taken  from the Test.Cardano.Api.Genesis example transaction here:
+          -- https://github.com/input-output-hk/cardano-node/blob/543b267d75d3d448e1940f9ec04b42bd01bbb16b/cardano-api/test/Test/Cardano/Api/Genesis.hs#L60
+          genesisKeyHash = C.GenesisUTxOKeyHash $ CardanoLedger.KeyHash "23d51e91ae5adc7ae801e9de4cd54175fb7464ec2680b25686bbb194"
+          inputs = [(C.genesisUTxOPseudoTxIn theNetworkId genesisKeyHash, C.BuildTxWith $ C.KeyWitness C.KeyWitnessForSpending)]
+      outputs <- mapM (txSkelOutToCardanoTxOut theNetworkId) initDist
+      mapLeft (TxBodyError "Body error") $ C.makeTransactionBody $ Ledger.emptyTxBodyContent {C.txMintValue = mintValue, C.txOuts = outputs, C.txIns = inputs}
 
 utxoIndex0 :: Ledger.UtxoIndex
 utxoIndex0 = utxoIndex0From def

--- a/src/Cooked/MockChain/Direct.hs
+++ b/src/Cooked/MockChain/Direct.hs
@@ -266,10 +266,10 @@ datumMap0From (InitialDistribution initDist) =
 --
 -- - inputs consist of a single dummy pseudo input
 --
--- - all assets in outputs are considered minted
+-- - all non-ada assets in outputs are considered minted
 --
 -- - outputs are translated from the `TxSkelOut` list in the initial
--- - distribution
+--   distribution
 utxoIndex0From :: InitialDistribution -> Ledger.UtxoIndex
 utxoIndex0From (InitialDistribution initDist) = case mkBody of
   Left err -> error $ show err

--- a/src/Cooked/MockChain/Testing.hs
+++ b/src/Cooked/MockChain/Testing.hs
@@ -7,7 +7,7 @@ module Cooked.MockChain.Testing where
 
 import qualified Control.Exception as E
 import Control.Monad
-import Cooked.Distribution
+import Cooked.InitialDistribution
 import Cooked.MockChain.BlockChain
 import Cooked.MockChain.Direct
 import Cooked.MockChain.Staged

--- a/src/Cooked/MockChain/Testing.hs
+++ b/src/Cooked/MockChain/Testing.hs
@@ -7,12 +7,12 @@ module Cooked.MockChain.Testing where
 
 import qualified Control.Exception as E
 import Control.Monad
+import Cooked.Distribution
 import Cooked.MockChain.BlockChain
 import Cooked.MockChain.Direct
 import Cooked.MockChain.Staged
 import Cooked.MockChain.UtxoState
 import Cooked.Pretty
-import Cooked.Wallet
 import Data.Default
 import qualified Data.Text as T
 import Debug.Trace

--- a/src/Cooked/Output.hs
+++ b/src/Cooked/Output.hs
@@ -101,6 +101,9 @@ instance ToOutputDatum () where
 instance ToOutputDatum Pl.DatumHash where
   toOutputDatum = Pl.OutputDatumHash
 
+instance ToOutputDatum Pl.BuiltinData where
+  toOutputDatum = toOutputDatum . Pl.Datum
+
 class ToValue a where
   toValue :: a -> Pl.Value
 

--- a/src/Cooked/Validators.hs
+++ b/src/Cooked/Validators.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+
+-- | This module introduces standard dummy validators to be used in
+-- attacks, traces or tests. More precisely, it introduces the always
+-- True and always False validators, which will respectively always
+-- succeed or always fail.
+module Cooked.Validators
+  ( alwaysTrueValidator,
+    alwaysFalseValidator,
+  )
+where
+
+import Cooked.RawUPLC
+import qualified Plutus.Script.Utils.V2.Typed.Scripts.Validators as Pl
+import qualified PlutusTx as Pl
+
+-- | The trivial validator that always succeds; this is in particular
+-- a sufficient target for the datum hijacking attack since we only
+-- want to show feasibility of the attack.
+alwaysTrueValidator :: Pl.TypedValidator a
+alwaysTrueValidator = unsafeTypedValidatorFromUPLC (Pl.getPlc $$(Pl.compile [||tgt||]))
+  where
+    tgt :: Pl.BuiltinData -> Pl.BuiltinData -> Pl.BuiltinData -> ()
+    tgt _ _ _ = ()
+
+-- | The trivial validator that always fails
+alwaysFalseValidator :: Pl.TypedValidator a
+alwaysFalseValidator = unsafeTypedValidatorFromUPLC (Pl.getPlc $$(Pl.compile [||tgt||]))
+  where
+    tgt :: Pl.BuiltinData -> Pl.BuiltinData -> Pl.BuiltinData -> ()
+    tgt _ _ _ = error "This validator always fails."

--- a/src/Cooked/Validators.hs
+++ b/src/Cooked/Validators.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- | This module introduces standard dummy validators to be used in
 -- attacks, traces or tests. More precisely, it introduces the always
@@ -10,6 +11,7 @@
 module Cooked.Validators
   ( alwaysTrueValidator,
     alwaysFalseValidator,
+    MockContract,
   )
 where
 
@@ -32,3 +34,10 @@ alwaysFalseValidator = unsafeTypedValidatorFromUPLC (Pl.getPlc $$(Pl.compile [||
   where
     tgt :: Pl.BuiltinData -> Pl.BuiltinData -> Pl.BuiltinData -> ()
     tgt _ _ _ = error "This validator always fails."
+
+-- | A Mock contract type to instantiate validators with
+data MockContract
+
+instance Pl.ValidatorTypes MockContract where
+  type RedeemerType MockContract = ()
+  type DatumType MockContract = ()

--- a/src/Cooked/ValueUtils.hs
+++ b/src/Cooked/ValueUtils.hs
@@ -1,9 +1,13 @@
+{-# LANGUAGE NumericUnderscores #-}
+
 -- | Utilities to work with Value
 module Cooked.ValueUtils
   ( flattenValueI,
     positivePart,
     negativePart,
     adaL,
+    lovelace,
+    ada,
   )
 where
 
@@ -40,12 +44,23 @@ adaL :: Lens' Pl.Value Pl.Ada
 adaL =
   lens
     Pl.fromValue
-    ( \value (Pl.Lovelace ada) ->
+    ( \value (Pl.Lovelace amount) ->
         over
           flattenValueI
-          (\l -> insertAssocList l (Pl.assetClass Pl.adaSymbol Pl.adaToken) ada)
+          (\l -> insertAssocList l adaAssetClass amount)
           value
     )
   where
     insertAssocList :: (Eq a) => [(a, b)] -> a -> b -> [(a, b)]
     insertAssocList l a b = (a, b) : filter ((/= a) . fst) l
+
+-- * Helpers for manipulating ada and lovelace
+
+adaAssetClass :: Pl.AssetClass
+adaAssetClass = Pl.assetClass Pl.adaSymbol Pl.adaToken
+
+lovelace :: Integer -> Pl.Value
+lovelace = Pl.assetClassValue adaAssetClass
+
+ada :: Integer -> Pl.Value
+ada = lovelace . (* 1_000_000)

--- a/tests/Cooked/Attack/DatumHijackingSpec.hs
+++ b/tests/Cooked/Attack/DatumHijackingSpec.hs
@@ -13,6 +13,7 @@ import Control.Monad
 import Cooked
 import Cooked.Attack.DatumHijacking
 import Cooked.MockChain.Staged
+import Cooked.Validators
 import Data.Default
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -171,7 +172,7 @@ tests =
     [ testGroup "unit tests on a 'TxSkel'" $
         let val1 = carelessValidator
             val2 = carefulValidator
-            thief = datumHijackingTarget @MockContract
+            thief = alwaysTrueValidator @MockContract
             x1 = Pl.lovelaceValueOf 10001
             x2 = Pl.lovelaceValueOf 10000
             x3 = Pl.lovelaceValueOf 9999

--- a/tests/Cooked/Attack/DatumHijackingSpec.hs
+++ b/tests/Cooked/Attack/DatumHijackingSpec.hs
@@ -13,7 +13,7 @@ import Control.Monad
 import Cooked
 import Cooked.Attack.DatumHijacking
 import Cooked.MockChain.Staged
-import Cooked.Validators
+import Cooked.Validators (alwaysTrueValidator)
 import Data.Default
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -38,32 +38,32 @@ import Test.Tasty.HUnit
 -- datum hijacking attack should target the second transaction, and substitute a
 -- different recipient.
 
-data MockDatum = FirstLock | SecondLock deriving (Show, Eq)
+data LockDatum = FirstLock | SecondLock deriving (Show, Eq)
 
-instance PrettyCooked MockDatum where
+instance PrettyCooked LockDatum where
   prettyCooked = viaShow
 
-instance Pl.Eq MockDatum where
+instance Pl.Eq LockDatum where
   {-# INLINEABLE (==) #-}
   FirstLock == FirstLock = True
   SecondLock == SecondLock = True
   _ == _ = False
 
-Pl.makeLift ''MockDatum
-Pl.unstableMakeIsData ''MockDatum
+Pl.makeLift ''LockDatum
+Pl.unstableMakeIsData ''LockDatum
 
-data MockContract
+data DHContract
 
-instance Pl.ValidatorTypes MockContract where
-  type DatumType MockContract = MockDatum
-  type RedeemerType MockContract = ()
+instance Pl.ValidatorTypes DHContract where
+  type DatumType DHContract = LockDatum
+  type RedeemerType DHContract = ()
 
 -- ** Transactions (and 'TxSkels') for the datum hijacking attack
 
 lockValue :: Pl.Value
 lockValue = Pl.lovelaceValueOf 12345678
 
-lockTxSkel :: Pl.TxOutRef -> Pl.TypedValidator MockContract -> TxSkel
+lockTxSkel :: Pl.TxOutRef -> Pl.TypedValidator DHContract -> TxSkel
 lockTxSkel o v =
   txSkelTemplate
     { txSkelOpts = def {txOptEnsureMinAda = True},
@@ -72,7 +72,7 @@ lockTxSkel o v =
       txSkelSigners = [wallet 1]
     }
 
-txLock :: (MonadBlockChain m) => Pl.TypedValidator MockContract -> m ()
+txLock :: (MonadBlockChain m) => Pl.TypedValidator DHContract -> m ()
 txLock v = do
   (oref, _) : _ <-
     runUtxoSearch $
@@ -80,7 +80,7 @@ txLock v = do
         `filterWithPred` ((`Pl.geq` lockValue) . outputValue)
   void $ validateTxSkel $ lockTxSkel oref v
 
-relockTxSkel :: Pl.TypedValidator MockContract -> Pl.TxOutRef -> TxSkel
+relockTxSkel :: Pl.TypedValidator DHContract -> Pl.TxOutRef -> TxSkel
 relockTxSkel v o =
   txSkelTemplate
     { txSkelOpts = def {txOptEnsureMinAda = True},
@@ -91,18 +91,18 @@ relockTxSkel v o =
 
 txRelock ::
   (MonadBlockChain m) =>
-  Pl.TypedValidator MockContract ->
+  Pl.TypedValidator DHContract ->
   m ()
 txRelock v = do
   (oref, _) : _ <-
     runUtxoSearch $
       utxosAtSearch (Pl.validatorAddress v)
         `filterWith` resolveDatum
-        `filterWithPure` isOutputWithInlineDatumOfType @MockDatum
+        `filterWithPure` isOutputWithInlineDatumOfType @LockDatum
         `filterWithPred` ((FirstLock ==) . (^. outputDatumL))
   void $ validateTxSkel $ relockTxSkel v oref
 
-datumHijackingTrace :: (MonadBlockChain m) => Pl.TypedValidator MockContract -> m ()
+datumHijackingTrace :: (MonadBlockChain m) => Pl.TypedValidator DHContract -> m ()
 datumHijackingTrace v = do
   txLock v
   txRelock v
@@ -111,7 +111,7 @@ datumHijackingTrace v = do
 
 -- | Try to extract a datum from an output.
 {-# INLINEABLE outputDatum #-}
-outputDatum :: Pl.TxInfo -> Pl.TxOut -> Maybe MockDatum
+outputDatum :: Pl.TxInfo -> Pl.TxOut -> Maybe LockDatum
 outputDatum txi o = case Pl.txOutDatum o of
   Pl.NoOutputDatum -> Nothing
   Pl.OutputDatumHash h -> do
@@ -120,7 +120,7 @@ outputDatum txi o = case Pl.txOutDatum o of
   Pl.OutputDatum (Pl.Datum d) -> Pl.fromBuiltinData d
 
 {-# INLINEABLE mkMockValidator #-}
-mkMockValidator :: (Pl.ScriptContext -> [Pl.TxOut]) -> MockDatum -> () -> Pl.ScriptContext -> Bool
+mkMockValidator :: (Pl.ScriptContext -> [Pl.TxOut]) -> LockDatum -> () -> Pl.ScriptContext -> Bool
 mkMockValidator getOutputs datum _ ctx =
   let txi = Pl.scriptContextTxInfo ctx
    in case datum of
@@ -137,24 +137,24 @@ mkMockValidator getOutputs datum _ ctx =
         SecondLock -> False
 
 {-# INLINEABLE mkCarefulValidator #-}
-mkCarefulValidator :: MockDatum -> () -> Pl.ScriptContext -> Bool
+mkCarefulValidator :: LockDatum -> () -> Pl.ScriptContext -> Bool
 mkCarefulValidator = mkMockValidator Pl.getContinuingOutputs
 
-carefulValidator :: Pl.TypedValidator MockContract
+carefulValidator :: Pl.TypedValidator DHContract
 carefulValidator =
-  Pl.mkTypedValidator @MockContract
+  Pl.mkTypedValidator @DHContract
     $$(Pl.compile [||mkCarefulValidator||])
     $$(Pl.compile [||wrap||])
   where
     wrap = Pl.mkUntypedValidator
 
 {-# INLINEABLE mkCarelessValidator #-}
-mkCarelessValidator :: MockDatum -> () -> Pl.ScriptContext -> Bool
+mkCarelessValidator :: LockDatum -> () -> Pl.ScriptContext -> Bool
 mkCarelessValidator = mkMockValidator (Pl.txInfoOutputs . Pl.scriptContextTxInfo)
 
-carelessValidator :: Pl.TypedValidator MockContract
+carelessValidator :: Pl.TypedValidator DHContract
 carelessValidator =
-  Pl.mkTypedValidator @MockContract
+  Pl.mkTypedValidator @DHContract
     $$(Pl.compile [||mkCarelessValidator||])
     $$(Pl.compile [||wrap||])
   where
@@ -172,7 +172,7 @@ tests =
     [ testGroup "unit tests on a 'TxSkel'" $
         let val1 = carelessValidator
             val2 = carefulValidator
-            thief = alwaysTrueValidator @MockContract
+            thief = alwaysTrueValidator @DHContract
             x1 = Pl.lovelaceValueOf 10001
             x2 = Pl.lovelaceValueOf 10000
             x3 = Pl.lovelaceValueOf 9999
@@ -186,7 +186,7 @@ tests =
                 ]
             skelOut bound select =
               runTweak
-                ( datumHijackingAttack @MockContract
+                ( datumHijackingAttack @DHContract
                     ( \(ConcreteOutput v _ x d _) ->
                         Pl.validatorHash val1
                           == Pl.validatorHash v
@@ -242,7 +242,7 @@ tests =
           def
           (isCekEvaluationFailure def)
           ( somewhere
-              ( datumHijackingAttack @MockContract
+              ( datumHijackingAttack @DHContract
                   ( \(ConcreteOutput v _ _ d _) ->
                       Pl.validatorHash v == Pl.validatorHash carefulValidator
                         && d == TxSkelOutInlineDatum SecondLock
@@ -255,7 +255,7 @@ tests =
         testSucceeds
           def
           ( somewhere
-              ( datumHijackingAttack @MockContract
+              ( datumHijackingAttack @DHContract
                   ( \(ConcreteOutput v _ _ d _) ->
                       Pl.validatorHash v == Pl.validatorHash carelessValidator
                         && d == TxSkelOutInlineDatum SecondLock

--- a/tests/Cooked/InitialDistributionSpec.hs
+++ b/tests/Cooked/InitialDistributionSpec.hs
@@ -7,56 +7,63 @@ import Control.Monad
 import Cooked
 import Data.Default
 import qualified Data.Map as Map
+import Data.Maybe (catMaybes)
 import qualified Plutus.Script.Utils.V2.Typed.Scripts.Validators as Pl
 import Test.Tasty
 import Test.Tasty.HUnit
 
--- | An initial distribution where wallet 1 owns a UTxO with a datum
--- of type Int and value 10
-initialDistributionWithDatum =
-  InitialDistribution
-    [withInlineDatum @Integer (paysPK (walletPKHash $ wallet 1) (ada 2)) 10]
+alice = wallet 1
 
--- | An initial distribution where wallet 1 owns a UTxO with a
+alicePKH = walletPKHash alice
+
+bob = wallet 2
+
+bobPKH = walletPKHash bob
+
+-- | An initial distribution where alice owns a UTxO with a datum
+-- of type Int and value 10 for each datum kind
+initialDistributionWithDatum =
+  InitialDistribution $
+    (\f -> f (paysPK alicePKH (ada 2)) 10)
+      <$> [withDatum @Integer, withInlineDatum, withDatumHash]
+
+-- | An initial distribution where alice owns a UTxO with a
 -- reference script corresponding to the always succeed validators
--- and wallet 2 owns 2 UTxOs with 100 ada
+-- and bob owns 2 UTxOs with 100 ada
 initialDistributionWithReferenceScript =
   InitialDistribution $
-    (paysPK (walletPKHash $ wallet 1) (ada 2) `withReferenceScript` alwaysTrueValidator @MockContract)
-      : replicate 2 (paysPK (walletPKHash $ wallet 2) (ada 100))
+    (paysPK alicePKH (ada 2) `withReferenceScript` alwaysTrueValidator @MockContract)
+      : replicate 2 (paysPK bobPKH (ada 100))
 
-getValueFromInitialDatum :: (MonadBlockChain m) => m Integer
+getValueFromInitialDatum :: (MonadBlockChain m) => m [Integer]
 getValueFromInitialDatum = do
-  [(txOutRef, _)] <- runUtxoSearch $ utxosAtSearch $ walletAddress $ wallet 1
-  Just datum <- typedDatumFromTxOutRef @Integer txOutRef
-  return datum
-
-printAndRun initDist trace = printCooked $ fst <$> interpretAndRunWith (runMockChainTFrom initDist) trace
+  aliceUtxos <- runUtxoSearch $ utxosAtSearch $ walletAddress alice
+  catMaybes <$> mapM (typedDatumFromTxOutRef @Integer . fst) aliceUtxos
 
 spendReferenceAlwaysTrueValidator :: (MonadBlockChain m) => m ()
 spendReferenceAlwaysTrueValidator = do
-  [(referenceScriptTxOutRef, _)] <- runUtxoSearch $ utxosAtSearch $ walletAddress $ wallet 1
+  [(referenceScriptTxOutRef, _)] <- runUtxoSearch $ utxosAtSearch $ walletAddress alice
   tx <-
     validateTxSkel $
       txSkelTemplate
         { txSkelOuts = [paysScript (alwaysTrueValidator @MockContract) () (ada 2)],
-          txSkelSigners = [wallet 2]
+          txSkelSigners = [bob]
         }
   let (scriptTxOutRef, _) : _ = utxosFromCardanoTx tx
   void $
     validateTxSkel $
       txSkelTemplate
-        { txSkelOuts = [paysPK (walletPKHash $ wallet 1) (ada 2)],
+        { txSkelOuts = [paysPK alicePKH (ada 2)],
           txSkelIns = Map.singleton scriptTxOutRef (TxSkelRedeemerForReferencedScript referenceScriptTxOutRef ()),
-          txSkelSigners = [wallet 2]
+          txSkelSigners = [bob]
         }
 
 tests :: TestTree
 tests =
   testGroup
     "initial distributions"
-    [ testCase "Reading a datum placed in the initial distribution" $
-        testSucceedsFrom' def (\n _ -> testBool $ n == 10) initialDistributionWithDatum getValueFromInitialDatum,
+    [ testCase "Reading datums placed in the initial distribution, inlined, hashed or vanilla" $
+        testSucceedsFrom' def (\results _ -> testBool $ results == [10, 10, 10]) initialDistributionWithDatum getValueFromInitialDatum,
       testCase "Spending a script placed as a reference script in the initial distribution" $
         testSucceedsFrom def initialDistributionWithReferenceScript spendReferenceAlwaysTrueValidator
     ]

--- a/tests/Cooked/InitialDistributionSpec.hs
+++ b/tests/Cooked/InitialDistributionSpec.hs
@@ -59,7 +59,8 @@ spendReferenceAlwaysTrueValidator = do
     validateTxSkel $
       txSkelTemplate
         { txSkelOuts = [paysPK (walletPKHash $ wallet 1) (ada 2)],
-          txSkelIns = Map.singleton scriptTxOutRef (TxSkelRedeemerForReferencedScript referenceScriptTxOutRef ())
+          txSkelIns = Map.singleton scriptTxOutRef (TxSkelRedeemerForReferencedScript referenceScriptTxOutRef ()),
+          txSkelSigners = [wallet 2]
         }
 
 tests :: TestTree

--- a/tests/Cooked/InitialDistributionSpec.hs
+++ b/tests/Cooked/InitialDistributionSpec.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cooked.InitialDistributionSpec where
+
+import Control.Monad
+import Cooked.InitialDistribution
+import Cooked.MockChain
+import Cooked.MockChain.Testing
+import Cooked.Skeleton
+import Cooked.Validators
+import Cooked.ValueUtils
+import Cooked.Wallet
+import Data.Default
+import qualified Data.Map as Map
+import qualified Plutus.Script.Utils.V2.Typed.Scripts.Validators as Pl
+import Test.Tasty
+import Test.Tasty.HUnit
+
+data MockContract
+
+instance Pl.ValidatorTypes MockContract where
+  type RedeemerType MockContract = ()
+  type DatumType MockContract = ()
+
+-- | An initial distribution where wallet 1 owns a UTxO with a datum
+-- of type Int and value 10
+initialDistributionWithDatum =
+  distributionFromList
+    [ (wallet 1, [datumToUTxOContent @Integer 10])
+    ]
+
+-- | An initial distribution where wallet 1 owns a UTxO with a
+-- reference script corresponding to the always succeed validators
+-- and wallet 2 owns 2 UTxOs with 100 ada
+initialDistributionWithReferenceScript =
+  distributionFromList
+    [ (wallet 1, [referenceScriptToUTxOContent $ alwaysTrueValidator @MockContract]),
+      (wallet 2, replicate 2 (valueToUTxOContent $ ada 100))
+    ]
+
+getValueFromInitialDatum :: (MonadBlockChain m) => m Integer
+getValueFromInitialDatum = do
+  [(txOutRef, _)] <- runUtxoSearch $ utxosAtSearch $ walletAddress $ wallet 1
+  Just datum <- typedDatumFromTxOutRef @Integer txOutRef
+  return datum
+
+spendReferenceAlwaysTrueValidator :: (MonadBlockChain m) => m ()
+spendReferenceAlwaysTrueValidator = do
+  [(referenceScriptTxOutRef, _)] <- runUtxoSearch $ utxosAtSearch $ walletAddress $ wallet 1
+  tx <-
+    validateTxSkel $
+      txSkelTemplate
+        { txSkelOuts = [paysScript (alwaysTrueValidator @MockContract) () (ada 2)],
+          txSkelSigners = [wallet 2]
+        }
+  let (scriptTxOutRef, _) : _ = utxosFromCardanoTx tx
+  void $
+    validateTxSkel $
+      txSkelTemplate
+        { txSkelOuts = [paysPK (walletPKHash $ wallet 1) (ada 2)],
+          txSkelIns = Map.singleton scriptTxOutRef (TxSkelRedeemerForReferencedScript referenceScriptTxOutRef ())
+        }
+
+tests :: TestTree
+tests =
+  testGroup
+    "initial distributions"
+    [ testCase "Reading a datum placed in the initial distribution" $
+        testSucceedsFrom' def (\n _ -> testBool $ n == 10) initialDistributionWithDatum getValueFromInitialDatum,
+      testCase "Spending a script placed as a reference script in the initial distribution" $
+        testSucceedsFrom def initialDistributionWithReferenceScript spendReferenceAlwaysTrueValidator
+    ]

--- a/tests/Cooked/ReferenceScriptsSpec.hs
+++ b/tests/Cooked/ReferenceScriptsSpec.hs
@@ -28,12 +28,6 @@ import qualified Prettyprinter as PP
 import Test.Tasty
 import Test.Tasty.HUnit
 
-data MockContract
-
-instance Pl.ValidatorTypes MockContract where
-  type RedeemerType MockContract = ()
-  type DatumType MockContract = ()
-
 -- | The validator that always agrees to the transaction
 yesValidator :: Pl.TypedValidator MockContract
 yesValidator =

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1,6 +1,8 @@
 import qualified Cooked.AttackSpec as AttackSpec
-import qualified Cooked.InlineDatumsSpec as InlineDatumsSpec
 -- import qualified Cooked.BalanceSpec as Ba
+
+import qualified Cooked.InitialDistributionSpec as InitDistrib
+import qualified Cooked.InlineDatumsSpec as InlineDatumsSpec
 import qualified Cooked.LtlSpec as LtlSpec
 import qualified Cooked.MinAdaSpec as MinAdaSpec
 import qualified Cooked.MockChainSpec as MockChainSpec
@@ -36,5 +38,6 @@ tests =
       TweakSpec.tests,
       LtlSpec.tests,
       MockChainSpec.tests,
-      ShowBSSpec.tests
+      ShowBSSpec.tests,
+      InitDistrib.tests
     ]


### PR DESCRIPTION
This PR introduces a richer initial distribution. The old initial distribution would only allow for Wallet to possess utxos containing values. The new initial distribution is extended to welcome any kind of initial payments. In particular, this includes:
* paying to a script
* attaching datums to initial utxos
* attaching reference scripts to initial utxos

The old helper to generate an initial distribution from wallets and values still exists, as this is the main use case. However, these new features would allow for instance to initialize oracles or have pre-existing reference scripts to be used when spending said scripts.

In addition, this PR introduces a module `Cooked.Validators` which contains dummy validators and associated datum types to be used in testing or redirecting outputs.