### PR TITLE
Add custom names pretty printing for hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
   `setValidityStartTweak` and `setValidityEndTweak`
 - UTxo searches with predicates over values, including only ada, or not only ada:
   `filterWithValuePred`, `filterWithOnlyAda` and `filterWithNotOnlyAda`
+- New pretty-printing options related to hashes in `pcOptHashes` including the
+  possibility to assign human readable names to hashes (pubkeys, scripts,
+  minting policies)
 
 ### Removed
 

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -34,6 +34,7 @@ library
       Cooked.Pretty.Class
       Cooked.Pretty.Common
       Cooked.Pretty.Cooked
+      Cooked.Pretty.Hashable
       Cooked.Pretty.Options
       Cooked.RawUPLC
       Cooked.ShowBS

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -25,6 +25,32 @@ initDist = initialDistribution [(i, [lovelaceValueOf 25_000_000]) | i <- knownWa
 * In a test `Tasty.testCase "foo" $ testSucceedsFrom def initDist foo`
 * In the REPL `printCooked $ interpretAndRunWith (runMockChainTFrom initDist) foo`
 
+### Give human-readable names to pubkey/script/minting hashes
+
+```haskell
+pcOpts :: C.PrettyCookedOpts
+pcOpts =
+  def
+    { C.pcOptHashes =
+        def
+          { C.pcOptHashNames =
+              defaultHashNames
+                <> C.hashNamesFromList
+                  [ (alice, "Alice"),
+                    (bob, "Bob"),
+                    (carrie, "Carie")
+                  ]
+                <> C.hashNamesFromList
+                  [ (nftCurrencySymbol, "NFT"),
+                    (customCoinsCurrencySymbol, "Custom Coins")
+                  ]
+                <> C.hashNamesFromList
+                  [ (fooValidator, "Foo")
+                  ]
+          }
+    }
+```
+
 ### Write a trace or endpoint
 
 ```haskell

--- a/src/Cooked/Pretty/Class.hs
+++ b/src/Cooked/Pretty/Class.hs
@@ -66,18 +66,7 @@ instance PrettyCooked Pl.Address where
     prettyCookedOpt opts addrCr <+> PP.angles ("staking:" <+> PP.pretty (p1, p2, p3))
 
 instance PrettyCooked Pl.PubKeyHash where
-  -- If the pubkey is a known wallet
-  -- #abcdef (wallet 3)
-  --
-  -- Otherwise
-  -- #123456
-  --
-  prettyCookedOpt opts pkh =
-    case walletPKHashToId pkh of
-      Nothing -> prettyHash (pcOptHashes opts) (toHash pkh)
-      Just walletId ->
-        prettyHash (pcOptHashes opts) (toHash pkh)
-          <+> PP.parens ("wallet" <+> PP.viaShow walletId)
+  prettyCookedOpt opts = prettyHash (pcOptHashes opts) . toHash
 
 instance PrettyCooked Pl.Credential where
   prettyCookedOpt opts (Pl.ScriptCredential vh) = "script" <+> prettyHash (pcOptHashes opts) (toHash vh)

--- a/src/Cooked/Pretty/Class.hs
+++ b/src/Cooked/Pretty/Class.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | We provide the 'PrettyCooked' class and instances for common Plutus types.
@@ -17,11 +16,9 @@ module Cooked.Pretty.Class
   )
 where
 
-import Cooked.Currencies (permanentCurrencySymbol, quickCurrencySymbol)
 import Cooked.Pretty.Common
 import Cooked.Pretty.Hashable
 import Cooked.Pretty.Options
-import Cooked.Wallet
 import Data.Default
 import qualified Ledger.Index as Pl
 import qualified Plutus.Script.Utils.Scripts as Pl
@@ -97,11 +94,7 @@ instance PrettyCooked Pl.Value where
         prettyCookedOpt opts (Pl.AssetClass (symbol, name)) <> ":" <+> prettyCookedOpt opts amount
 
 instance PrettyCooked Pl.CurrencySymbol where
-  prettyCookedOpt opts symbol
-    | symbol == Pl.CurrencySymbol "" = "Lovelace"
-    | symbol == quickCurrencySymbol = "Quick"
-    | symbol == permanentCurrencySymbol = "Permanent"
-    | otherwise = prettyHash (pcOptHashes opts) (toHash symbol)
+  prettyCookedOpt opts symbol = prettyHash (pcOptHashes opts) (toHash symbol)
 
 instance PrettyCooked Pl.TokenName where
   prettyCookedOpt _ = PP.pretty

--- a/src/Cooked/Pretty/Class.hs
+++ b/src/Cooked/Pretty/Class.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | We provide the 'PrettyCooked' class and instances for common Plutus types.
@@ -18,6 +19,7 @@ where
 
 import Cooked.Currencies (permanentCurrencySymbol, quickCurrencySymbol)
 import Cooked.Pretty.Common
+import Cooked.Pretty.Hashable
 import Cooked.Pretty.Options
 import Cooked.Wallet
 import Data.Default
@@ -47,14 +49,14 @@ printCooked :: (PrettyCooked a) => a -> IO ()
 printCooked = printCookedOpt def
 
 instance PrettyCooked Pl.TxId where
-  prettyCookedOpt opts = prettyHash (pcOptPrintedHashLength opts)
+  prettyCookedOpt opts = prettyHash (pcOptHashes opts) . toHash
 
 instance PrettyCooked Pl.TxOutRef where
   prettyCookedOpt opts (Pl.TxOutRef txId index) =
-    prettyHash (pcOptPrintedHashLength opts) txId <> "!" <> prettyCookedOpt opts index
+    prettyHash (pcOptHashes opts) (toHash txId) <> "!" <> prettyCookedOpt opts index
 
 instance PrettyCooked (Pl.Versioned Pl.MintingPolicy) where
-  prettyCookedOpt opts = prettyHash (pcOptPrintedHashLength opts) . Pl.mintingPolicyHash
+  prettyCookedOpt opts = prettyHash (pcOptHashes opts) . toHash
 
 instance PrettyCooked Pl.Address where
   prettyCookedOpt opts (Pl.Address addrCr Nothing) = prettyCookedOpt opts addrCr
@@ -72,13 +74,13 @@ instance PrettyCooked Pl.PubKeyHash where
   --
   prettyCookedOpt opts pkh =
     case walletPKHashToId pkh of
-      Nothing -> prettyHash (pcOptPrintedHashLength opts) pkh
+      Nothing -> prettyHash (pcOptHashes opts) (toHash pkh)
       Just walletId ->
-        prettyHash (pcOptPrintedHashLength opts) pkh
+        prettyHash (pcOptHashes opts) (toHash pkh)
           <+> PP.parens ("wallet" <+> PP.viaShow walletId)
 
 instance PrettyCooked Pl.Credential where
-  prettyCookedOpt opts (Pl.ScriptCredential vh) = "script" <+> prettyHash (pcOptPrintedHashLength opts) vh
+  prettyCookedOpt opts (Pl.ScriptCredential vh) = "script" <+> prettyHash (pcOptHashes opts) (toHash vh)
   prettyCookedOpt opts (Pl.PubKeyCredential pkh) = "pubkey" <+> prettyCookedOpt opts pkh
 
 instance PrettyCooked Pl.Value where
@@ -110,7 +112,7 @@ instance PrettyCooked Pl.CurrencySymbol where
     | symbol == Pl.CurrencySymbol "" = "Lovelace"
     | symbol == quickCurrencySymbol = "Quick"
     | symbol == permanentCurrencySymbol = "Permanent"
-    | otherwise = prettyHash (pcOptPrintedHashLength opts) symbol
+    | otherwise = prettyHash (pcOptHashes opts) (toHash symbol)
 
 instance PrettyCooked Pl.TokenName where
   prettyCookedOpt _ = PP.pretty
@@ -132,7 +134,7 @@ instance PrettyCooked Pl.POSIXTime where
   prettyCookedOpt opts (Pl.POSIXTime n) = "POSIXTime" <+> prettyCookedOpt opts n
 
 instance PrettyCooked Pl.ScriptHash where
-  prettyCookedOpt opts = prettyHash (pcOptPrintedHashLength opts)
+  prettyCookedOpt opts = prettyHash (pcOptHashes opts) . toHash
 
 instance (PrettyCooked a) => PrettyCooked [a] where
   prettyCookedOpt opts = prettyItemizeNoTitle "-" . map (prettyCookedOpt opts)

--- a/src/Cooked/Pretty/Common.hs
+++ b/src/Cooked/Pretty/Common.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 -- | Common tools to help implement pretty-printers in cooked-validators
 module Cooked.Pretty.Common
@@ -12,6 +13,11 @@ module Cooked.Pretty.Common
   )
 where
 
+import Cooked.Pretty.Options (PrettyCookedHashOpts (..))
+import qualified Data.ByteString as ByteString
+import qualified Data.Map as Map
+import qualified Numeric
+import qualified PlutusTx.Builtins.Internal as Pl (BuiltinByteString (..))
 import Prettyprinter (Doc, (<+>))
 import qualified Prettyprinter as PP
 import qualified Prettyprinter.Render.String as PP
@@ -54,5 +60,20 @@ prettyEnumerate title bullet items =
     ]
 
 -- | Pretty print a prefix of a hash with a given length.
-prettyHash :: (Show a) => Int -> a -> DocCooked
-prettyHash printedLength = PP.pretty . ('#' :) . take printedLength . show
+prettyHash :: PrettyCookedHashOpts -> Pl.BuiltinByteString -> DocCooked
+prettyHash PrettyCookedHashOpts {..} bbs@(Pl.BuiltinByteString bs) =
+  let hexRepresentation :: DocCooked
+      hexRepresentation =
+        PP.pretty $
+          ( take pcOptHashLength
+              . concatMap (`Numeric.showHex` "")
+              . ByteString.unpack
+          )
+            bs
+   in case Map.lookup bbs pcOptHashNames of
+        Nothing -> "#" <> hexRepresentation
+        Just name ->
+          PP.pretty name
+            <+> if pcOptHashVerbose
+              then PP.parens ("#" <> hexRepresentation)
+              else mempty

--- a/src/Cooked/Pretty/Common.hs
+++ b/src/Cooked/Pretty/Common.hs
@@ -64,16 +64,16 @@ prettyHash :: PrettyCookedHashOpts -> Pl.BuiltinByteString -> DocCooked
 prettyHash PrettyCookedHashOpts {..} bbs@(Pl.BuiltinByteString bs) =
   let hexRepresentation :: DocCooked
       hexRepresentation =
-        PP.pretty $
-          ( take pcOptHashLength
-              . concatMap (`Numeric.showHex` "")
-              . ByteString.unpack
-          )
+        "#"
+          <> ( PP.pretty
+                 . take pcOptHashLength
+                 . concatMap (`Numeric.showHex` "")
+                 . ByteString.unpack
+             )
             bs
    in case Map.lookup bbs pcOptHashNames of
-        Nothing -> "#" <> hexRepresentation
+        Nothing -> hexRepresentation
         Just name ->
-          PP.pretty name
-            <+> if pcOptHashVerbose
-              then PP.parens ("#" <> hexRepresentation)
-              else mempty
+          if pcOptHashVerbose
+            then hexRepresentation <+> PP.parens (PP.pretty name)
+            else PP.pretty name

--- a/src/Cooked/Pretty/Cooked.hs
+++ b/src/Cooked/Pretty/Cooked.hs
@@ -41,6 +41,7 @@ import Cooked.MockChain.UtxoState
 import Cooked.Output
 import Cooked.Pretty.Class
 import Cooked.Pretty.Common
+import Cooked.Pretty.Hashable
 import Cooked.Pretty.Options
 import Cooked.Skeleton
 import Cooked.Wallet
@@ -133,12 +134,12 @@ instance PrettyCooked MockChainError where
     prettyItemize
       "Unknown validator hash:"
       "-"
-      [PP.pretty msg, "hash:" <+> prettyHash (pcOptPrintedHashLength opts) valHash]
+      [PP.pretty msg, "hash:" <+> prettyHash (pcOptHashes opts) (toHash valHash)]
   prettyCookedOpt opts (MCEUnknownDatum msg dHash) =
     prettyItemize
       "Unknown datum hash:"
       "-"
-      [PP.pretty msg, "hash:" <+> prettyHash (pcOptPrintedHashLength opts) dHash]
+      [PP.pretty msg, "hash:" <+> prettyHash (pcOptHashes opts) (toHash dHash)]
   prettyCookedOpt _ (OtherMockChainError err) =
     prettyItemize
       "Miscellaneous MockChainError:"
@@ -336,7 +337,10 @@ getReferenceScriptDoc :: (IsAbstractOutput output, ToScriptHash (ReferenceScript
 getReferenceScriptDoc opts output =
   case output ^. outputReferenceScriptL of
     Nothing -> Nothing
-    Just refScript -> Just $ "Reference script hash:" <+> prettyHash (pcOptPrintedHashLength opts) (toScriptHash refScript)
+    Just refScript ->
+      Just $
+        "Reference script hash:"
+          <+> prettyHash (pcOptHashes opts) (toHash . toScriptHash $ refScript)
 
 lookupOutput ::
   SkelContext ->
@@ -510,4 +514,4 @@ prettyPayload
 prettyReferenceScriptHash :: PrettyCookedOpts -> Pl.ScriptHash -> DocCooked
 prettyReferenceScriptHash opts scriptHash =
   "Reference script hash:"
-    <+> prettyHash (pcOptPrintedHashLength opts) scriptHash
+    <+> prettyHash (pcOptHashes opts) (toHash scriptHash)

--- a/src/Cooked/Pretty/Hashable.hs
+++ b/src/Cooked/Pretty/Hashable.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
+module Cooked.Pretty.Hashable where
+
+import Cooked.Wallet (Wallet, walletPKHash)
+import qualified Plutus.Script.Utils.Scripts as Pl
+import qualified Plutus.Script.Utils.Typed as Pl
+import qualified Plutus.Script.Utils.V1.Typed.Scripts as Pl
+import qualified Plutus.Script.Utils.Value as Pl
+import qualified Plutus.V1.Ledger.Tx as Pl
+import qualified Plutus.V2.Ledger.Api as Pl
+
+class Hashable a where
+  toHash :: a -> Pl.BuiltinByteString
+
+instance Hashable Pl.CurrencySymbol where
+  toHash = Pl.unCurrencySymbol
+
+instance Hashable Pl.PubKeyHash where
+  toHash = Pl.getPubKeyHash
+
+instance Hashable Wallet where
+  toHash = toHash . walletPKHash
+
+instance Hashable (Pl.Versioned Pl.MintingPolicy) where
+  toHash mintingPolicy =
+    let Pl.MintingPolicyHash hash = Pl.mintingPolicyHash mintingPolicy
+     in hash
+
+instance Hashable Pl.ScriptHash where
+  toHash = Pl.getScriptHash
+
+instance Hashable Pl.ValidatorHash where
+  toHash (Pl.ValidatorHash hash) = hash
+
+instance Hashable (Pl.TypedValidator a) where
+  toHash = toHash . Pl.validatorAddress
+
+instance Hashable Pl.DatumHash where
+  toHash (Pl.DatumHash hash) = hash
+
+instance Hashable Pl.TxId where
+  toHash = Pl.getTxId
+
+instance Hashable Pl.Address where
+  toHash (Pl.Address (Pl.PubKeyCredential pkh) _) = toHash pkh
+  toHash (Pl.Address (Pl.ScriptCredential vh) _) = toHash vh

--- a/src/Cooked/Pretty/Options.hs
+++ b/src/Cooked/Pretty/Options.hs
@@ -1,11 +1,21 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
 -- | Pretty-printing options for 'prettyCookedOpt' and their default values.
 module Cooked.Pretty.Options
   ( PrettyCookedOpts (..),
+    PrettyCookedHashOpts (..),
     PCOptTxOutRefs (..),
+    hashNamesFromList,
   )
 where
 
+import Cooked.Pretty.Hashable
+import Data.Bifunctor (first)
 import Data.Default
+import Data.Map (Map)
+import qualified Data.Map as Map
+import qualified PlutusTx.Prelude as Pl
 
 data PrettyCookedOpts = PrettyCookedOpts
   { -- | Whether to print transaction ids of validated transactions.
@@ -18,15 +28,24 @@ data PrettyCookedOpts = PrettyCookedOpts
     -- default.
     -- By default: False
     pcOptPrintDefaultTxOpts :: Bool,
-    -- | Length of printed hashes (e.g. addresses, transaction ids)
-    -- By default: 7
-    pcOptPrintedHashLength :: Int,
     -- | Whether to print big integers with numeric underscores.
     -- For example @53_000_000@ instead of @53000000@.
     -- By default: True
-    pcOptNumericUnderscores :: Bool
+    pcOptNumericUnderscores :: Bool,
+    -- | Options relative to printing hashes
+    pcOptHashes :: PrettyCookedHashOpts
   }
   deriving (Eq, Show)
+
+instance Default PrettyCookedOpts where
+  def =
+    PrettyCookedOpts
+      { pcOptPrintTxHashes = False,
+        pcOptPrintTxOutRefs = PCOptTxOutRefsHidden,
+        pcOptPrintDefaultTxOpts = False,
+        pcOptNumericUnderscores = True,
+        pcOptHashes = def
+      }
 
 -- | Whether to print transaction outputs references.
 data PCOptTxOutRefs
@@ -42,12 +61,34 @@ data PCOptTxOutRefs
     PCOptTxOutRefsPartial
   deriving (Eq, Show)
 
-instance Default PrettyCookedOpts where
+data PrettyCookedHashOpts = PrettyCookedHashOpts
+  { -- | Length of printed hashes (e.g. addresses, transaction ids)
+    -- By default: 7
+    pcOptHashLength :: Int,
+    -- | Association between hashes and given names to ease readability.
+    -- For example @Map.singleton (walletPKHash (wallet 1)) "Alice"@
+    -- By default: @Map.empty@
+    pcOptHashNames :: Map Pl.BuiltinByteString String,
+    -- | When a given name exists for a hash, this flag also prints the
+    -- original hash after the name
+    -- By default: @False@
+    pcOptHashVerbose :: Bool,
+    -- | Try to parse token names as hashes and, if applicable, display the
+    -- associated given name.
+    -- By default: @True@
+    -- TODO NOT YET IMPLEMENTED
+    pcOptHashParseTokenNames :: Bool
+  }
+  deriving (Eq, Show)
+
+instance Default PrettyCookedHashOpts where
   def =
-    PrettyCookedOpts
-      { pcOptPrintTxHashes = False,
-        pcOptPrintTxOutRefs = PCOptTxOutRefsHidden,
-        pcOptPrintDefaultTxOpts = False,
-        pcOptPrintedHashLength = 7,
-        pcOptNumericUnderscores = True
+    PrettyCookedHashOpts
+      { pcOptHashLength = 7,
+        pcOptHashNames = Map.empty,
+        pcOptHashVerbose = False,
+        pcOptHashParseTokenNames = True
       }
+
+hashNamesFromList :: (Hashable a) => [(a, String)] -> Map Pl.BuiltinByteString String
+hashNamesFromList = Map.fromList . map (first toHash)

--- a/src/Cooked/Pretty/Options.hs
+++ b/src/Cooked/Pretty/Options.hs
@@ -106,5 +106,7 @@ defaultHashNames =
       (permanentCurrencySymbol, "Permanent")
     ]
 
+-- | Smart constructor for maps to be used in the "pcOptHashNames"
+-- pretty-printing option.
 hashNamesFromList :: (Hashable a) => [(a, String)] -> Map Pl.BuiltinByteString String
 hashNamesFromList = Map.fromList . map (first toHash)

--- a/src/Cooked/Pretty/Options.hs
+++ b/src/Cooked/Pretty/Options.hs
@@ -76,12 +76,7 @@ data PrettyCookedHashOpts = PrettyCookedHashOpts
     -- | When a given name exists for a hash, this flag also prints the
     -- original hash after the name
     -- By default: @False@
-    pcOptHashVerbose :: Bool,
-    -- | Try to parse token names as hashes and, if applicable, display the
-    -- associated given name.
-    -- By default: @True@
-    -- TODO NOT YET IMPLEMENTED
-    pcOptHashParseTokenNames :: Bool
+    pcOptHashVerbose :: Bool
   }
   deriving (Eq, Show)
 
@@ -90,8 +85,7 @@ instance Default PrettyCookedHashOpts where
     PrettyCookedHashOpts
       { pcOptHashLength = 7,
         pcOptHashNames = defaultHashNames,
-        pcOptHashVerbose = False,
-        pcOptHashParseTokenNames = True
+        pcOptHashVerbose = False
       }
 
 -- | Default hash to names map that assigns Lovelace, Quick, and Permanent to


### PR DESCRIPTION
This addresses #379 

This PR introduces a quality of life feature to associate readable names to hashes in a new pretty-pretting option.

The option is grouped among others in the `pcOptHashes` field of `PrettyCookedOpts`. This field has the following subfields:

* `pcOptHashLength`: this option already existed before, at the top level of `PrettyCookedOpts`, it sets how many characters of a hash to print
* `pcOptHashNames`: This is the core of the new feature, it associates hashes to names. Use the `hashNamesFromList` smart constructor. It takes a list of key/value pairs but the keys can be anything that has a hash: wallets, scripts, minting policies, datums, transaction ids, and pretty much all the associated types (might not be exhaustive). The associated new class, `Hashable`, is defined in `Pretty.Cooked.Hashable`.
* `pcOptHashVerbose`: By default, when a corresponding name is found for a hash, the hex representation is no longer printed. This flag forces it to be printed alongside the name just in case.
* ~~`pcOptHashParseTokenNames`: Not yet implemented. This is intended to parse token names for a hex representation of a hash and if something is found in `pcOptHashNames`, print it instead.~~ (postponed)

Example:

```haskell
pcOpts :: C.PrettyCookedOpts
pcOpts =
  def
    { C.pcOptHashes =
        def
          { C.pcOptHashNames =
              defaultHashNames
                <> C.hashNamesFromList
                  [ (alice, "Alice"),
                    (bob, "Bob"),
                    (carrie, "Carie")
                  ]
                <> C.hashNamesFromList
                  [ (nftCurrencySymbol, "NFT"),
                    (customCoinsCurrencySymbol, "Custom Coins")
                  ]
                <> C.hashNamesFromList
                  [ (fooValidator, "Foo")
                  ]
          }
    }

```

### TODO and discussion topics
* [x] Remove the feature which used to display wallet numbers (they are still displayed which is useless now)
* ~~Maybe stop displaying "pubkey" vs "script" as a prefix when a hash has been resolved to a name _(I lean towards keeping it)_~~
* [x] Investigate or postpone to future PR the token name parsing feature
* [x] Experiment with highlighting names from the rest of the text. Hashes where easy to spot because of the `#` and hexadecimal characters. Now names, in particular if they have spaces or are lowercased, can be hard to notice in the middle of the text. For example `Spends from script foo (Reference Script at 28282838!0)`, or `Pays to pubkey Clint Eastwood` could become `Pays to pubkey [Clint Eastwood]` or `Spends from script [foo]`, `Pays to pubkey #"Clint Eastwood"`, etc. _(I'd keep it like it is for now)_
* ~~Investigate using existential types or something to avoid having to split the names into several sublists for each concrete type. _(That would be nice to have)_~~
* [x] There was a hardcoded check to print "Lovelace"/"Quick"/"Permanent" for the relevant currency symbols. Should this now be moved to the default name table (which would contain those 3 elements instead of being empty by default)? _(I find it would be conceptually more elegant but maybe prone to accidental overwrites in practice)_