### PR TITLE
Unresolved `TxOut` pretty printing bug resolution

### DIFF
--- a/src/Cooked/Pretty/Cooked.hs
+++ b/src/Cooked/Pretty/Cooked.hs
@@ -334,18 +334,9 @@ prettyTxSkelInReference opts skelContext txOutRef = do
       )
 
 getReferenceScriptDoc :: (IsAbstractOutput output, ToScriptHash (ReferenceScriptType output)) => PrettyCookedOpts -> output -> Maybe DocCooked
-getReferenceScriptDoc opts output =
-  case output ^. outputReferenceScriptL of
-    Nothing -> Nothing
-    Just refScript ->
-      Just $
-        "Reference script hash:"
-          <+> prettyHash (pcOptHashes opts) (toHash . toScriptHash $ refScript)
+getReferenceScriptDoc opts output = prettyReferenceScriptHash opts . toScriptHash <$> output ^. outputReferenceScriptL
 
-lookupOutput ::
-  SkelContext ->
-  Pl.TxOutRef ->
-  Maybe (Pl.TxOut, Maybe TxSkelOutDatum)
+lookupOutput :: SkelContext -> Pl.TxOutRef -> Maybe (Pl.TxOut, Maybe TxSkelOutDatum)
 lookupOutput (SkelContext managedTxOuts managedTxSkelOutDatums) txOutRef = do
   output <- Map.lookup txOutRef managedTxOuts
   return

--- a/src/Cooked/Pretty/Cooked.hs
+++ b/src/Cooked/Pretty/Cooked.hs
@@ -339,11 +339,13 @@ getReferenceScriptDoc opts output = prettyReferenceScriptHash opts . toScriptHas
 lookupOutput :: SkelContext -> Pl.TxOutRef -> Maybe (Pl.TxOut, TxSkelOutDatum)
 lookupOutput (SkelContext managedTxOuts managedTxSkelOutDatums) txOutRef = do
   output <- Map.lookup txOutRef managedTxOuts
-  let txSkelOutDatum = case outputOutputDatum output of
+  return
+    ( output,
+      case outputOutputDatum output of
         Pl.OutputDatum datum -> Map.findWithDefault TxSkelOutNoDatum (Pl.datumHash datum) managedTxSkelOutDatums
         Pl.OutputDatumHash datumHash -> Map.findWithDefault TxSkelOutNoDatum datumHash managedTxSkelOutDatums
         Pl.NoOutputDatum -> TxSkelOutNoDatum
-  return (output, txSkelOutDatum)
+    )
 
 -- | Pretty-print a list of transaction skeleton options, only printing an
 -- option if its value is non-default. If no non-default options are in the

--- a/src/Cooked/Pretty/Options.hs
+++ b/src/Cooked/Pretty/Options.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 
 -- | Pretty-printing options for 'prettyCookedOpt' and their default values.
 module Cooked.Pretty.Options
@@ -8,6 +7,7 @@ module Cooked.Pretty.Options
     PrettyCookedHashOpts (..),
     PCOptTxOutRefs (..),
     hashNamesFromList,
+    defaultHashNames,
   )
 where
 


### PR DESCRIPTION
This fixes #385.
The issue was in function `lookupOutput` where `TxOut`s would only be resolved when they had a datum which was a mistake.
This also fixes a small redundancy when printing reference scripts.