### PR TITLE
Rely entirely on CHaP

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -35,8 +35,8 @@ repository cardano-haskell-packages
 
 -- See CONTRIBUTING.adoc for how to update index-state
 index-state:
-  , hackage.haskell.org 2024-01-01T00:00:00Z
-  , cardano-haskell-packages 2024-01-01T00:00:00Z
+  , hackage.haskell.org 2024-04-11T00:00:00Z
+  , cardano-haskell-packages 2024-04-11T00:00:00Z
 
 -- We never, ever, want this.
 write-ghc-environment-files: never

--- a/cabal.project
+++ b/cabal.project
@@ -8,16 +8,6 @@ package cooked-validators
 package cardano-crypto-praos
   flags: -external-libsodium-vrf
 
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-node-emulator
-  tag: 1e09173b74064bd5990d2d3e48af6510780ea349
-  subdir:
-    cardano-node-emulator
-    plutus-ledger
-    plutus-script-utils
-    freer-extras
-    
 -- Everything below this point has been copied from cardano-node-emulator cabal.project
 
 -- Custom repository for cardano haskell packages


### PR DESCRIPTION
This PR removes the last `source-repository-package`. This involves bumping the
`index-state` of Hackage and CHaP so as to take `cardano-node-emulator` from
CHaP. The Nix environment can now provide all the system and Haskell
dependencies; building with Cabal from scratch now only builds Cooked
Validators.