### PR TITLE
Trimming down ValueUtils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Removed
 
+- `positivePart` and `negativePart` in `ValueUtils.hs`. Replaced by `Api.split`.
+
 ### Changed
 
 - Internal representation of redeemers have changed, and are similar for any

--- a/src/Cooked/ValueUtils.hs
+++ b/src/Cooked/ValueUtils.hs
@@ -1,8 +1,6 @@
 -- | This module provides utilities to work with Value
 module Cooked.ValueUtils
   ( flattenValueI,
-    positivePart,
-    negativePart,
     adaL,
     lovelace,
     ada,
@@ -14,29 +12,12 @@ import Optics.Core
 import Plutus.Script.Utils.Ada qualified as Script
 import Plutus.Script.Utils.Value qualified as Script hiding (adaSymbol, adaToken)
 import PlutusLedgerApi.V3 qualified as Api
-import PlutusTx.Numeric qualified as PlutusTx
 
 flattenValueI :: Iso' Api.Value [(Script.AssetClass, Integer)]
 flattenValueI =
   iso
     (map (\(cSymbol, tName, amount) -> (Script.assetClass cSymbol tName, amount)) . Script.flattenValue)
     (foldl' (\v (ac, amount) -> v <> Script.assetClassValue ac amount) mempty)
-
--- | The positive part of a value. For every asset class in the given value,
--- this asset class and its amount are included in the output iff the amount is
--- strictly positive. It holds
---
--- > x == positivePart x <> Script.negate negativePart x
-positivePart :: Api.Value -> Api.Value
-positivePart = over flattenValueI (filter $ (0 <) . snd)
-
--- | The negative part of a value. For every asset class in the given value,
--- this asset class and its negated amount are included in the output iff the
--- amount is strictly negative. It holds
---
--- > x == positivePart x <> Script.negate negativePart x
-negativePart :: Api.Value -> Api.Value
-negativePart = positivePart . PlutusTx.negate
 
 -- | Focus the Ada part in a value.
 adaL :: Lens' Api.Value Script.Ada


### PR DESCRIPTION
This trims down `ValueUtils` by removing `positivePart` and `negativePart`. These were already replaced in the codebase by `Api.split.`  This is one step towards resolution of issue #399 