### PR TITLE
PR1: Slightly optimizing and fixing initial distrubutions handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 - `positivePart` and `negativePart` in `ValueUtils.hs`. Replaced by `Api.split`.
 - Redundant logging of errors in mockchain runs.
+- Useless minting of non-ADA value in the dummy initial transaction.
 
 ### Changed
 
@@ -66,6 +67,8 @@
   in the excess.
 - Transactions that do not involve script are now properly generated without any
 - All kinds of scripts can now be used as reference scripts.
+- A bug where scripts being paid to in the initial distribution would not be
+  stored in the MockChain.
 
 ## [[4.0.0]](https://github.com/tweag/cooked-validators/releases/tag/v4.0.0) - 2024-06-28
 

--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -57,31 +57,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724967942,
-        "narHash": "sha256-27l+z2H57dWuuWSt1lBs1YKnluHYS1dwcDM1jtb6cr8=",
+        "lastModified": 1739549106,
+        "narHash": "sha256-bNX5Kgtq+H3SWoEGK0X8gWLwEV5r1wXJnSJqGNiT78M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b9fe0f3209d5b6800cace23d2423c8622382cfe1",
+        "rev": "5d18af8a53e73f111d691004e3a35808966ce155",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -92,15 +76,14 @@
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
+        ]
       },
       "locked": {
-        "lastModified": 1724857454,
-        "narHash": "sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk=",
+        "lastModified": 1737465171,
+        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
             zlib
             xz
             glibcLocales
+            openssl_3_3
             postgresql # For pg_config
             ## We change the way 'blst' is built so that it takes into
             ## account the current architecture of the processor. This
@@ -65,6 +66,7 @@
               libsodium
               zlib
               xz
+              openssl_3_3
               postgresql # For cardano-node-emulator
               openldap # For freer-extras‽
             ];

--- a/src/Cooked/MockChain/MockChainSt.hs
+++ b/src/Cooked/MockChain/MockChainSt.hs
@@ -15,7 +15,6 @@ import Cooked.Output
 import Cooked.Skeleton
 import Data.Bifunctor (bimap)
 import Data.Default
-import Data.Either.Combinators (mapLeft)
 import Data.List (foldl')
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -163,15 +162,15 @@ mockChainSt0 = MockChainSt def utxoIndex0 Map.empty Map.empty 0
 -- * Initial `MockChainSt` from an initial distribution
 
 mockChainSt0From :: InitialDistribution -> MockChainSt
-mockChainSt0From i0 = MockChainSt def (utxoIndex0From i0) (datumMap0From i0) (referenceScriptMap0From i0) 0
+mockChainSt0From i0 = MockChainSt def (utxoIndex0From i0) (datumMap0From i0) (referenceScriptMap0From i0 <> scriptMap0From i0) 0
 
 -- | Reference scripts from initial distributions should be accounted for in the
 -- `MockChainSt` which is done using this function.
 referenceScriptMap0From :: InitialDistribution -> Map Script.ValidatorHash (Script.Versioned Script.Validator)
-referenceScriptMap0From (InitialDistribution initDist) =
+referenceScriptMap0From =
   -- This builds a map of entries from the reference scripts contained in the
   -- initial distribution
-  Map.fromList $ mapMaybe unitMaybeFrom initDist
+  Map.fromList . mapMaybe unitMaybeFrom . unInitialDistribution
   where
     -- This takes a single output and returns a possible map entry when it
     -- contains a reference script
@@ -179,8 +178,22 @@ referenceScriptMap0From (InitialDistribution initDist) =
     unitMaybeFrom (Pays output) = do
       refScript <- view outputReferenceScriptL output
       let vScript@(Script.Versioned script version) = toVersionedScript refScript
-          Api.ScriptHash scriptHash = toScriptHash vScript
-      return (Script.ValidatorHash scriptHash, Script.Versioned (Script.Validator script) version)
+      return (Script.ValidatorHash $ Api.getScriptHash $ toScriptHash vScript, Script.Versioned (Script.Validator script) version)
+
+-- | Scripts from initial distributions should be accounted for in the
+-- `MockChainSt` which is done using this function.
+scriptMap0From :: InitialDistribution -> Map Script.ValidatorHash (Script.Versioned Script.Validator)
+scriptMap0From =
+  -- This builds a map of entries from the scripts contained in the initial
+  -- distribution
+  Map.fromList . mapMaybe unitMaybeFrom . unInitialDistribution
+  where
+    -- This takes a single output and returns a possible map entry when it
+    -- contains a script
+    unitMaybeFrom :: TxSkelOut -> Maybe (Script.ValidatorHash, Script.Versioned Script.Validator)
+    unitMaybeFrom txSkelOut = do
+      val <- txSkelOutValidator txSkelOut
+      return (Script.ValidatorHash $ Api.getScriptHash $ toScriptHash val, val)
 
 -- | Datums from initial distributions should be accounted for in the
 -- `MockChainSt` which is done using this function.
@@ -222,15 +235,13 @@ utxoIndex0From (InitialDistribution initDist) = case mkBody of
   where
     mkBody :: Either GenerateTxError (Cardano.TxBody Cardano.ConwayEra)
     mkBody = do
-      value <- mapLeft (ToCardanoError "Value error") $ Ledger.toCardanoValue (foldl' (\v -> (v <>) . view txSkelOutValueL) mempty initDist)
-      let mintValue = flip (Cardano.TxMintValue Cardano.MaryEraOnwardsConway) (Cardano.BuildTxWith mempty) . Cardano.filterValue (/= Cardano.AdaAssetId) $ value
-          theNetworkId = Cardano.Testnet $ Cardano.NetworkMagic 42
+      let theNetworkId = Cardano.Testnet $ Cardano.NetworkMagic 42
           genesisKeyHash = Cardano.GenesisUTxOKeyHash $ Shelley.KeyHash "23d51e91ae5adc7ae801e9de4cd54175fb7464ec2680b25686bbb194"
           inputs = [(Cardano.genesisUTxOPseudoTxIn theNetworkId genesisKeyHash, Cardano.BuildTxWith $ Cardano.KeyWitness Cardano.KeyWitnessForSpending)]
       outputs <- mapM (generateTxOut theNetworkId) initDist
       left (TxBodyError "Body error") $
         Cardano.createAndValidateTransactionBody Cardano.ShelleyBasedEraConway $
-          Ledger.emptyTxBodyContent {Cardano.txMintValue = mintValue, Cardano.txOuts = outputs, Cardano.txIns = inputs}
+          Ledger.emptyTxBodyContent {Cardano.txOuts = outputs, Cardano.txIns = inputs}
 
 utxoIndex0 :: Ledger.UtxoIndex
 utxoIndex0 = utxoIndex0From def


### PR DESCRIPTION
This PR introduces 4 changes:
* 1 bug-fix: scripts are now stored in the mockchain state when hen paid to in initial distributions.
* 1 slight optimization: useless minting in initial distribution dummy transaction has been removed.
* a first miscellaneous change: update in flake.lock (due to libblst issue)
* a second miscellaneous change: adding openssl 3.3 as a nix dependency.