### PR TITLE
Updating warnings and default language extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Nix caches
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@v16
         with:
           name: tweag-cooked-validators
           ## This auth token will give write access to the cache, meaning that
@@ -59,7 +59,7 @@ jobs:
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Nix caches
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@v16
         with:
           name: tweag-cooked-validators
           ## This auth token will give write access to the cache, meaning that
@@ -91,7 +91,7 @@ jobs:
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Nix caches
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@v16
         with:
           name: tweag-cooked-validators
           ## No auth token: read only cache.
@@ -218,7 +218,7 @@ jobs:
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Nix caches
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@v16
         with:
           name: tweag-cooked-validators
           ## No auth token: read only cache.
@@ -284,7 +284,7 @@ jobs:
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Nix caches
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@v16
         with:
           name: tweag-cooked-validators
           ## This auth token will give write access to the cache, meaning that

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v30
+        uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
             ## Access token to avoid triggering GitHub's rate limiting.
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v30
+        uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
             ## Access token to avoid triggering GitHub's rate limiting.
@@ -84,7 +84,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v30
+        uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
             ## Access token to avoid triggering GitHub's rate limiting.
@@ -211,7 +211,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v30
+        uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
             ## Access token to avoid triggering GitHub's rate limiting.
@@ -277,7 +277,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v30
+        uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
             ## Access token to avoid triggering GitHub's rate limiting.

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -88,7 +88,6 @@ library
       src
   default-extensions:
       ImportQualifiedPost
-      AllowAmbiguousTypes
       ConstraintKinds
       DataKinds
       DerivingStrategies
@@ -100,6 +99,7 @@ library
       ImportQualifiedPost
       LambdaCase
       MultiParamTypeClasses
+      MultiWayIf
       NamedFieldPuns
       NumericUnderscores
       OverloadedStrings
@@ -107,7 +107,6 @@ library
       RecordWildCards
       ScopedTypeVariables
       StandaloneDeriving
-      StrictData
       TemplateHaskell
       TupleSections
       TypeApplications
@@ -115,7 +114,7 @@ library
       TypeOperators
       TypeSynonymInstances
       ViewPatterns
-  ghc-options: -Wall -Wno-missed-extra-shared-lib -fobject-code -fno-ignore-interface-pragmas -fignore-hpc-changes -fno-omit-interface-pragmas -fplugin-opt PlutusTx.Plugin:defer-errors -fplugin-opt PlutusTx.Plugin:conservative-optimisation
+  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -Wno-missed-extra-shared-lib -fobject-code -fno-ignore-interface-pragmas -fignore-hpc-changes -fno-omit-interface-pragmas -fplugin-opt PlutusTx.Plugin:defer-errors -fplugin-opt PlutusTx.Plugin:conservative-optimisation
   build-depends:
       QuickCheck
     , base >=4.9 && <5
@@ -192,24 +191,33 @@ test-suite spec
       tests/
   default-extensions:
       ImportQualifiedPost
+      ConstraintKinds
       DataKinds
+      DerivingStrategies
+      DerivingVia
       FlexibleContexts
       FlexibleInstances
       GADTs
+      GeneralizedNewtypeDeriving
+      ImportQualifiedPost
       LambdaCase
       MultiParamTypeClasses
       MultiWayIf
+      NamedFieldPuns
       NumericUnderscores
       OverloadedStrings
       RankNTypes
       RecordWildCards
       ScopedTypeVariables
+      StandaloneDeriving
       TemplateHaskell
       TupleSections
       TypeApplications
       TypeFamilies
+      TypeOperators
+      TypeSynonymInstances
       ViewPatterns
-  ghc-options: -Wall -Wno-missed-extra-shared-lib -Wno-type-defaults -fobject-code -fno-ignore-interface-pragmas -fignore-hpc-changes -fno-omit-interface-pragmas -fplugin-opt PlutusTx.Plugin:defer-errors -fplugin-opt PlutusTx.Plugin:conservative-optimisation
+  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -Wno-missed-extra-shared-lib -fobject-code -fno-ignore-interface-pragmas -fignore-hpc-changes -fno-omit-interface-pragmas -fplugin-opt PlutusTx.Plugin:defer-errors -fplugin-opt PlutusTx.Plugin:conservative-optimisation
   build-depends:
       QuickCheck
     , base >=4.9 && <5
@@ -238,7 +246,6 @@ test-suite spec
     , nonempty-containers
     , optics-core
     , optics-th
-    , parsec
     , plutus-core
     , plutus-ledger
     , plutus-ledger-api

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -87,7 +87,6 @@ library
   hs-source-dirs:
       src
   default-extensions:
-      ImportQualifiedPost
       ConstraintKinds
       DataKinds
       DerivingStrategies
@@ -103,6 +102,7 @@ library
       NamedFieldPuns
       NumericUnderscores
       OverloadedStrings
+      PolyKinds
       RankNTypes
       RecordWildCards
       ScopedTypeVariables
@@ -112,7 +112,6 @@ library
       TypeApplications
       TypeFamilies
       TypeOperators
-      TypeSynonymInstances
       ViewPatterns
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -Wno-missed-extra-shared-lib -fobject-code -fno-ignore-interface-pragmas -fignore-hpc-changes -fno-omit-interface-pragmas -fplugin-opt PlutusTx.Plugin:defer-errors -fplugin-opt PlutusTx.Plugin:conservative-optimisation
   build-depends:
@@ -190,7 +189,6 @@ test-suite spec
   hs-source-dirs:
       tests/
   default-extensions:
-      ImportQualifiedPost
       ConstraintKinds
       DataKinds
       DerivingStrategies
@@ -206,6 +204,7 @@ test-suite spec
       NamedFieldPuns
       NumericUnderscores
       OverloadedStrings
+      PolyKinds
       RankNTypes
       RecordWildCards
       ScopedTypeVariables
@@ -215,7 +214,6 @@ test-suite spec
       TypeApplications
       TypeFamilies
       TypeOperators
-      TypeSynonymInstances
       ViewPatterns
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -Wno-missed-extra-shared-lib -fobject-code -fno-ignore-interface-pragmas -fignore-hpc-changes -fno-omit-interface-pragmas -fplugin-opt PlutusTx.Plugin:defer-errors -fplugin-opt PlutusTx.Plugin:conservative-optimisation
   build-depends:

--- a/package.yaml
+++ b/package.yaml
@@ -63,7 +63,6 @@ library:
     -fplugin-opt PlutusTx.Plugin:defer-errors
     -fplugin-opt PlutusTx.Plugin:conservative-optimisation
   default-extensions: &default-extensions
-    - ImportQualifiedPost
     - ConstraintKinds
     - DataKinds
     - DerivingStrategies
@@ -79,6 +78,7 @@ library:
     - NamedFieldPuns
     - NumericUnderscores
     - OverloadedStrings
+    - PolyKinds
     - RankNTypes
     - RecordWildCards
     - ScopedTypeVariables
@@ -88,7 +88,6 @@ library:
     - TypeApplications
     - TypeFamilies
     - TypeOperators
-    - TypeSynonymInstances
     - ViewPatterns
 
 tests:

--- a/package.yaml
+++ b/package.yaml
@@ -46,11 +46,15 @@ dependencies:
   - tasty-quickcheck
   - text
   - transformers
-
+    
 library:
   source-dirs: src
-  ghc-options:
+  ghc-options: &ghc-options
     -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
     -Wno-missed-extra-shared-lib
     -fobject-code
     -fno-ignore-interface-pragmas
@@ -58,9 +62,8 @@ library:
     -fno-omit-interface-pragmas
     -fplugin-opt PlutusTx.Plugin:defer-errors
     -fplugin-opt PlutusTx.Plugin:conservative-optimisation
-  default-extensions:
+  default-extensions: &default-extensions
     - ImportQualifiedPost
-    - AllowAmbiguousTypes
     - ConstraintKinds
     - DataKinds
     - DerivingStrategies
@@ -72,6 +75,7 @@ library:
     - ImportQualifiedPost
     - LambdaCase
     - MultiParamTypeClasses
+    - MultiWayIf
     - NamedFieldPuns
     - NumericUnderscores
     - OverloadedStrings
@@ -79,7 +83,6 @@ library:
     - RecordWildCards
     - ScopedTypeVariables
     - StandaloneDeriving
-    - StrictData
     - TemplateHaskell
     - TupleSections
     - TypeApplications
@@ -93,35 +96,7 @@ tests:
     main: Spec.hs
     source-dirs:
       - tests/
-    ghc-options:
-      -Wall
-      -Wno-missed-extra-shared-lib
-      -Wno-type-defaults
-      -fobject-code
-      -fno-ignore-interface-pragmas
-      -fignore-hpc-changes
-      -fno-omit-interface-pragmas
-      -fplugin-opt PlutusTx.Plugin:defer-errors
-      -fplugin-opt PlutusTx.Plugin:conservative-optimisation
+    ghc-options: *ghc-options  
     dependencies:
       - cooked-validators
-      - parsec
-    default-extensions:
-      - ImportQualifiedPost
-      - DataKinds
-      - FlexibleContexts
-      - FlexibleInstances
-      - GADTs
-      - LambdaCase
-      - MultiParamTypeClasses
-      - MultiWayIf
-      - NumericUnderscores
-      - OverloadedStrings
-      - RankNTypes
-      - RecordWildCards
-      - ScopedTypeVariables
-      - TemplateHaskell
-      - TupleSections
-      - TypeApplications
-      - TypeFamilies
-      - ViewPatterns
+    default-extensions: *default-extensions

--- a/src/Cooked/Attack/DatumHijacking.hs
+++ b/src/Cooked/Attack/DatumHijacking.hs
@@ -29,11 +29,7 @@ import Type.Reflection
 -- @(Script.TypedValidator a)@ might be useful to construct the optics used by
 -- this tweak.
 redirectScriptOutputTweak ::
-  ( MonadTweak m,
-    Is k A_Traversal,
-    Show (Script.DatumType a),
-    Api.ToData (Script.DatumType a)
-  ) =>
+  (MonadTweak m, Is k A_Traversal) =>
   Optic' k is TxSkel (ConcreteOutput (Script.TypedValidator a) TxSkelOutDatum Api.Value (Script.Versioned Script.Script)) ->
   -- | Return @Just@ the new validator, or @Nothing@ if you want to leave this
   -- output unchanged.
@@ -69,15 +65,7 @@ redirectScriptOutputTweak optic change =
 -- attack fails.
 datumHijackingAttack ::
   forall a m.
-  ( MonadTweak m,
-    Show (Script.DatumType a),
-    PrettyCooked (Script.DatumType a),
-    Api.ToData (Script.DatumType a),
-    Api.UnsafeFromData (Script.DatumType a),
-    Api.UnsafeFromData (Script.RedeemerType a),
-    Typeable (Script.DatumType a),
-    Typeable a
-  ) =>
+  (MonadTweak m, Typeable a) =>
   -- | Predicate to select outputs to steal, depending on the intended
   -- recipient, the datum, and the value.
   (ConcreteOutput (Script.TypedValidator a) TxSkelOutDatum Api.Value (Script.Versioned Script.Script) -> Bool) ->

--- a/src/Cooked/InitialDistribution.hs
+++ b/src/Cooked/InitialDistribution.hs
@@ -15,7 +15,7 @@ import Cooked.MockChain.MinAda
 import Cooked.Skeleton
 import Cooked.Wallet
 import Data.Default
-import Data.List
+import Data.List (foldl')
 import Plutus.Script.Utils.Value qualified as Script
 import PlutusLedgerApi.V3 qualified as Api
 

--- a/src/Cooked/Ltl.hs
+++ b/src/Cooked/Ltl.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE UndecidableInstances #-}
-
 -- | This modules provides the infrastructure to modify sequences of
 -- transactions using LTL formulaes with atomic modifications. This idea is to
 -- describe when to apply certain modifications within a trace. This is to be

--- a/src/Cooked/MockChain/Balancing.hs
+++ b/src/Cooked/MockChain/Balancing.hs
@@ -24,7 +24,7 @@ import Cooked.Skeleton
 import Cooked.Wallet
 import Data.Bifunctor
 import Data.Function
-import Data.List
+import Data.List (find, partition, sortBy)
 import Data.Map qualified as Map
 import Data.Maybe
 import Data.Ratio qualified as Rat

--- a/src/Cooked/MockChain/Direct.hs
+++ b/src/Cooked/MockChain/Direct.hs
@@ -64,7 +64,6 @@ instance (Monad m, Alternative m) => Alternative (MockChainT m) where
   (<|>) = combineMockChainT (<|>)
 
 combineMockChainT ::
-  (Monad m) =>
   (forall a. m a -> m a -> m a) ->
   MockChainT m x ->
   MockChainT m x ->
@@ -86,7 +85,6 @@ mapMockChainT f = MockChainT . mapStateT (mapExceptT (mapWriterT f)) . unMockCha
 -- | Executes a 'MockChainT' from some initial state; does /not/ convert the
 -- 'MockChainSt' into a 'UtxoState'.
 runMockChainTRaw ::
-  (Monad m) =>
   MockChainSt ->
   MockChainT m a ->
   m (MockChainReturn a MockChainSt)

--- a/src/Cooked/MockChain/Testing.hs
+++ b/src/Cooked/MockChain/Testing.hs
@@ -181,11 +181,11 @@ emptyTest trace =
     }
 
 -- | Appending an initial distribution to a test
-withInitDist :: (IsProp prop) => Test a prop -> InitialDistribution -> Test a prop
+withInitDist :: Test a prop -> InitialDistribution -> Test a prop
 withInitDist test initDist = test {testInitDist = initDist}
 
 -- | Appending printing options to a test
-withPrettyOpts :: (IsProp prop) => Test a prop -> PrettyCookedOpts -> Test a prop
+withPrettyOpts :: Test a prop -> PrettyCookedOpts -> Test a prop
 withPrettyOpts test opts = test {testPrettyOpts = opts}
 
 -- | Appending a predicate over the log to a test. This will be used both in

--- a/src/Cooked/Skeleton/Payable.hs
+++ b/src/Cooked/Skeleton/Payable.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE TypeOperators #-}
-
 module Cooked.Skeleton.Payable
   ( Payable (..),
     (<&&>),

--- a/src/Cooked/Tweak/Common.hs
+++ b/src/Cooked/Tweak/Common.hs
@@ -29,7 +29,7 @@ import Control.Monad.State
 import Cooked.MockChain.BlockChain
 import Cooked.Skeleton
 import Data.Either.Combinators (rightToMaybe)
-import Data.List
+import Data.List (mapAccumL)
 import Data.Maybe
 import ListT (ListT)
 import ListT qualified
@@ -68,7 +68,7 @@ instance (MonadBlockChainWithoutValidation m) => MonadTweak (Tweak m) where
 -- If you're using tweaks in a 'MonadModalBlockChain' together with mechanisms
 -- like 'withTweak', 'somewhere', or 'everywhere', you should never have areason
 -- to use this function.
-runTweakInChain :: (MonadBlockChainWithoutValidation m, MonadPlus m) => Tweak m a -> TxSkel -> m (a, TxSkel)
+runTweakInChain :: (MonadPlus m) => Tweak m a -> TxSkel -> m (a, TxSkel)
 runTweakInChain tweak skel = ListT.alternate $ runStateT tweak skel
 
 -- | Like 'runTweakInChain', but for when you want to explicitly apply a tweak

--- a/src/Cooked/Tweak/Mint.hs
+++ b/src/Cooked/Tweak/Mint.hs
@@ -7,7 +7,7 @@ where
 
 import Cooked.Skeleton
 import Cooked.Tweak.Common
-import Data.List
+import Data.List (partition)
 import Optics.Core
 import Plutus.Script.Utils.Scripts qualified as Script
 import PlutusLedgerApi.V3 qualified as Api

--- a/src/Cooked/Tweak/Outputs.hs
+++ b/src/Cooked/Tweak/Outputs.hs
@@ -16,7 +16,7 @@ import Cooked.Pretty.Class
 import Cooked.Skeleton
 import Cooked.Tweak.Common
 import Cooked.Tweak.Labels
-import Data.List
+import Data.List (partition)
 import Data.Maybe
 import Data.Typeable
 import Optics.Core
@@ -58,7 +58,7 @@ instance PrettyCooked TamperDatumLbl where
 --
 -- The tweak returns a list of the modified datums, as they were *before* the
 -- modification was applied to them.
-tamperDatumTweak :: forall a m. (MonadTweak m, Show a, PrettyCooked a, Api.ToData a, Api.FromData a, Typeable a) => (a -> Maybe a) -> m [a]
+tamperDatumTweak :: forall a m. (MonadTweak m, Api.FromData a, Typeable a) => (a -> Maybe a) -> m [a]
 tamperDatumTweak change = do
   beforeModification <- overMaybeTweak (txSkelOutsL % traversed % txSkelOutputDatumTypeAT) change
   guard . not . null $ beforeModification
@@ -83,7 +83,7 @@ tamperDatumTweak change = do
 -- > == (k_1 + 1) * ... * (k_n + 1) - 1
 --
 -- modified transactions.
-malformDatumTweak :: forall a m. (MonadTweak m, Api.ToData a, Api.FromData a, Typeable a) => (a -> [Api.BuiltinData]) -> m ()
+malformDatumTweak :: forall a m. (MonadTweak m, Typeable a) => (a -> [Api.BuiltinData]) -> m ()
 malformDatumTweak change = do
   outputs <- viewAllTweak (txSkelOutsL % traversed)
   let modifiedOutputs = map (\output -> output : changeOutput output) outputs

--- a/tests/Cooked/Tweak/CommonSpec.hs
+++ b/tests/Cooked/Tweak/CommonSpec.hs
@@ -1,7 +1,7 @@
 module Cooked.Tweak.CommonSpec (tests) where
 
 import Cooked
-import Data.List
+import Data.List (subsequences)
 import Optics.Core
 import Plutus.Script.Utils.Ada qualified as Script
 import Plutus.Script.Utils.Value qualified as Script


### PR DESCRIPTION
This is a small and simple PR that:
* Slightly changes our default language extensions
* Removes useless (and undesirable) usage of `AllowAmbiguousTypes`, `StrictData` and `UndecidableInstances`
* Adds some useful warnings by default (and solves them)
* Improves our `package.yaml` by avoiding repetitions

In particulars, this closes #413 

I added some dependabot updates to this PR which deals with the overall configuration of the projects to lighten the main history.