### PR TITLE
Release cooked v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Added
 
+### Removed
+
+### Changed
+
+### Fixed
+
+## [[6.0.0]](https://github.com/tweag/cooked-validators/releases/tag/v6.0.0) - 2025-05-15
+
+### Added
+
 - Module `Cooked.Pretty.Hashable` has been brought back from
   `Cooked.Conversion.ToHash` since it has no purpose being in
   `plutus-script-utils`.

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -5,7 +5,7 @@ cabal-version: 3.4
 -- see: https://github.com/sol/hpack
 
 name:           cooked-validators
-version:        5.0.0
+version:        6.0.0
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple

--- a/package.yaml
+++ b/package.yaml
@@ -2,7 +2,7 @@ verbatim:
   cabal-version: 3.4
 
 name: cooked-validators
-version: 5.0.0
+version: 6.0.0
 
 dependencies:
   - QuickCheck


### PR DESCRIPTION
This changes the version of cooked to prepare release v6.0.0.

This should be merged as soon as [this](https://github.com/IntersectMBO/cardano-node-emulator/pull/41) is merged and the commit on CNE has been updated accordingly.